### PR TITLE
feat: Support Storybook v6 Controls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,24 +8,27 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
       "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-      "dev": true,
       "requires": {
         "@babel/highlight": "^7.8.3"
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.7.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.7.0.tgz",
-      "integrity": "sha512-Dv3hLKIC1jyfTkClvyEkYP2OlkzNvWs5+Q8WgPbxM5LMeorons7iPP91JM+DU7tRbhqA1ZeooPaMFvQrn23RHw==",
+      "version": "7.10.4",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
+      "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
       "requires": {
-        "@babel/types": "^7.7.0"
+        "@babel/types": "^7.10.4"
       }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.10.4",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+      "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
     },
     "@babel/highlight": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
       "integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
-      "dev": true,
       "requires": {
         "chalk": "^2.0.0",
         "esutils": "^2.0.2",
@@ -33,708 +36,751 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.2.tgz",
-      "integrity": "sha512-JONRbXbTXc9WQE2mAZd1p0Z3DZ/6vaQIkgYMSTP3KjRCyd7rCZCcfhCyX+YjwcKxcZ82UrxbRD358bpExNgrjw==",
+      "version": "7.11.2",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@babel/runtime/-/runtime-7.11.2.tgz",
+      "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
       "requires": {
-        "regenerator-runtime": "^0.13.2"
+        "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/types": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.7.2.tgz",
-      "integrity": "sha512-YTf6PXoh3+eZgRCBzzP25Bugd2ngmpQVrk7kXX0i5N9BO7TFBtIgZYs7WtxtOGs8e6A4ZI7ECkbBCEHeXocvOA==",
+      "version": "7.11.0",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@babel/types/-/types-7.11.0.tgz",
+      "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
       "requires": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.17.13",
+        "@babel/helper-validator-identifier": "^7.10.4",
+        "lodash": "^4.17.19",
         "to-fast-properties": "^2.0.0"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+        }
       }
     },
     "@emotion/cache": {
-      "version": "10.0.19",
-      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.19.tgz",
-      "integrity": "sha512-BoiLlk4vEsGBg2dAqGSJu0vJl/PgVtCYLBFJaEO8RmQzPugXewQCXZJNXTDFaRlfCs0W+quesayav4fvaif5WQ==",
+      "version": "10.0.29",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@emotion/cache/-/cache-10.0.29.tgz",
+      "integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
       "requires": {
-        "@emotion/sheet": "0.9.3",
-        "@emotion/stylis": "0.8.4",
-        "@emotion/utils": "0.11.2",
-        "@emotion/weak-memoize": "0.2.4"
+        "@emotion/sheet": "0.9.4",
+        "@emotion/stylis": "0.8.5",
+        "@emotion/utils": "0.11.3",
+        "@emotion/weak-memoize": "0.2.5"
       }
     },
     "@emotion/core": {
-      "version": "10.0.22",
-      "resolved": "https://registry.npmjs.org/@emotion/core/-/core-10.0.22.tgz",
-      "integrity": "sha512-7eoP6KQVUyOjAkE6y4fdlxbZRA4ILs7dqkkm6oZUJmihtHv0UBq98VgPirq9T8F9K2gKu0J/au/TpKryKMinaA==",
+      "version": "10.0.35",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@emotion/core/-/core-10.0.35.tgz",
+      "integrity": "sha512-sH++vJCdk025fBlRZSAhkRlSUoqSqgCzYf5fMOmqqi3bM6how+sQpg3hkgJonj8GxXM4WbD7dRO+4tegDB9fUw==",
       "requires": {
         "@babel/runtime": "^7.5.5",
-        "@emotion/cache": "^10.0.17",
-        "@emotion/css": "^10.0.22",
-        "@emotion/serialize": "^0.11.12",
-        "@emotion/sheet": "0.9.3",
-        "@emotion/utils": "0.11.2"
+        "@emotion/cache": "^10.0.27",
+        "@emotion/css": "^10.0.27",
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/sheet": "0.9.4",
+        "@emotion/utils": "0.11.3"
       }
     },
     "@emotion/css": {
-      "version": "10.0.22",
-      "resolved": "https://registry.npmjs.org/@emotion/css/-/css-10.0.22.tgz",
-      "integrity": "sha512-8phfa5mC/OadBTmGpMpwykIVH0gFCbUoO684LUkyixPq4F1Wwri7fK5Xlm8lURNBrd2TuvTbPUGxFsGxF9UacA==",
+      "version": "10.0.27",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@emotion/css/-/css-10.0.27.tgz",
+      "integrity": "sha512-6wZjsvYeBhyZQYNrGoR5yPMYbMBNEnanDrqmsqS1mzDm1cOTu12shvl2j4QHNS36UaTE0USIJawCH9C8oW34Zw==",
       "requires": {
-        "@emotion/serialize": "^0.11.12",
-        "@emotion/utils": "0.11.2",
-        "babel-plugin-emotion": "^10.0.22"
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/utils": "0.11.3",
+        "babel-plugin-emotion": "^10.0.27"
       }
     },
     "@emotion/hash": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.7.3.tgz",
-      "integrity": "sha512-14ZVlsB9akwvydAdaEnVnvqu6J2P6ySv39hYyl/aoB6w/V+bXX0tay8cF6paqbgZsN2n5Xh15uF4pE+GvE+itw=="
+      "version": "0.8.0",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@emotion/hash/-/hash-0.8.0.tgz",
+      "integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
     },
     "@emotion/is-prop-valid": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.5.tgz",
-      "integrity": "sha512-6ZODuZSFofbxSbcxwsFz+6ioPjb0ISJRRPLZ+WIbjcU2IMU0Io+RGQjjaTgOvNQl007KICBm7zXQaYQEC1r6Bg==",
+      "version": "0.8.8",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
       "requires": {
-        "@emotion/memoize": "0.7.3"
+        "@emotion/memoize": "0.7.4"
       }
     },
     "@emotion/memoize": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.3.tgz",
-      "integrity": "sha512-2Md9mH6mvo+ygq1trTeVp2uzAKwE2P7In0cRpD/M9Q70aH8L+rxMLbb3JCN2JoSWsV2O+DdFjfbbXoMoLBczow=="
+      "version": "0.7.4",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
     },
     "@emotion/serialize": {
-      "version": "0.11.14",
-      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.14.tgz",
-      "integrity": "sha512-6hTsySIuQTbDbv00AnUO6O6Xafdwo5GswRlMZ5hHqiFx+4pZ7uGWXUQFW46Kc2taGhP89uXMXn/lWQkdyTosPA==",
+      "version": "0.11.16",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@emotion/serialize/-/serialize-0.11.16.tgz",
+      "integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
       "requires": {
-        "@emotion/hash": "0.7.3",
-        "@emotion/memoize": "0.7.3",
-        "@emotion/unitless": "0.7.4",
-        "@emotion/utils": "0.11.2",
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/unitless": "0.7.5",
+        "@emotion/utils": "0.11.3",
         "csstype": "^2.5.7"
       }
     },
     "@emotion/sheet": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.3.tgz",
-      "integrity": "sha512-c3Q6V7Df7jfwSq5AzQWbXHa5soeE4F5cbqi40xn0CzXxWW9/6Mxq48WJEtqfWzbZtW9odZdnRAkwCQwN12ob4A=="
+      "version": "0.9.4",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@emotion/sheet/-/sheet-0.9.4.tgz",
+      "integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
     },
     "@emotion/styled": {
-      "version": "10.0.23",
-      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-10.0.23.tgz",
-      "integrity": "sha512-gNr04eqBQ2iYUx8wFLZDfm3N8/QUOODu/ReDXa693uyQGy2OqA+IhPJk+kA7id8aOfwAsMuvZ0pJImEXXKtaVQ==",
+      "version": "10.0.27",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@emotion/styled/-/styled-10.0.27.tgz",
+      "integrity": "sha512-iK/8Sh7+NLJzyp9a5+vIQIXTYxfT4yB/OJbjzQanB2RZpvmzBQOHZWhpAMZWYEKRNNbsD6WfBw5sVWkb6WzS/Q==",
       "requires": {
-        "@emotion/styled-base": "^10.0.23",
-        "babel-plugin-emotion": "^10.0.23"
+        "@emotion/styled-base": "^10.0.27",
+        "babel-plugin-emotion": "^10.0.27"
       }
     },
     "@emotion/styled-base": {
-      "version": "10.0.24",
-      "resolved": "https://registry.npmjs.org/@emotion/styled-base/-/styled-base-10.0.24.tgz",
-      "integrity": "sha512-AnBImerf0h4dGAJVo0p0VE8KoAns71F28ErGFK474zbNAHX6yqSWQUasb+1jvg/VPwZjCp19+tAr6oOB0pwmLQ==",
+      "version": "10.0.31",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@emotion/styled-base/-/styled-base-10.0.31.tgz",
+      "integrity": "sha512-wTOE1NcXmqMWlyrtwdkqg87Mu6Rj1MaukEoEmEkHirO5IoHDJ8LgCQL4MjJODgxWxXibGR3opGp1p7YvkNEdXQ==",
       "requires": {
         "@babel/runtime": "^7.5.5",
-        "@emotion/is-prop-valid": "0.8.5",
-        "@emotion/serialize": "^0.11.14",
-        "@emotion/utils": "0.11.2"
+        "@emotion/is-prop-valid": "0.8.8",
+        "@emotion/serialize": "^0.11.15",
+        "@emotion/utils": "0.11.3"
       }
     },
     "@emotion/stylis": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.4.tgz",
-      "integrity": "sha512-TLmkCVm8f8gH0oLv+HWKiu7e8xmBIaokhxcEKPh1m8pXiV/akCiq50FvYgOwY42rjejck8nsdQxZlXZ7pmyBUQ=="
+      "version": "0.8.5",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@emotion/stylis/-/stylis-0.8.5.tgz",
+      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
     },
     "@emotion/unitless": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.4.tgz",
-      "integrity": "sha512-kBa+cDHOR9jpRJ+kcGMsysrls0leukrm68DmFQoMIWQcXdr2cZvyvypWuGYT7U+9kAExUE7+T7r6G3C3A6L8MQ=="
+      "version": "0.7.5",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@emotion/unitless/-/unitless-0.7.5.tgz",
+      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
     },
     "@emotion/utils": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.2.tgz",
-      "integrity": "sha512-UHX2XklLl3sIaP6oiMmlVzT0J+2ATTVpf0dHQVyPJHTkOITvXfaSqnRk6mdDhV9pR8T/tHc3cex78IKXssmzrA=="
+      "version": "0.11.3",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@emotion/utils/-/utils-0.11.3.tgz",
+      "integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
     },
     "@emotion/weak-memoize": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.4.tgz",
-      "integrity": "sha512-6PYY5DVdAY1ifaQW6XYTnOMihmBVT27elqSjEoodchsGjzYlEsTQMcEhSud99kVawatyTZRTiVkJ/c6lwbQ7nA=="
+      "version": "0.2.5",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
+      "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
     "@icons/material": {
       "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@icons/material/-/material-0.2.4.tgz",
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw=="
     },
     "@reach/router": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@reach/router/-/router-1.2.1.tgz",
-      "integrity": "sha512-kTaX08X4g27tzIFQGRukaHmNbtMYDS3LEWIS8+l6OayGIw6Oyo1HIF/JzeuR2FoF9z6oV+x/wJSVSq4v8tcUGQ==",
+      "version": "1.3.4",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@reach/router/-/router-1.3.4.tgz",
+      "integrity": "sha512-+mtn9wjlB9NN2CNnnC/BRYtwdKBfSyyasPYraNAyvaV1occr/5NnB4CVzjEZipNHwYebQwcndGUmpFzxAUoqSA==",
       "requires": {
-        "create-react-context": "^0.2.1",
+        "create-react-context": "0.3.0",
         "invariant": "^2.2.3",
         "prop-types": "^15.6.1",
-        "react-lifecycles-compat": "^3.0.4",
-        "warning": "^3.0.0"
+        "react-lifecycles-compat": "^3.0.4"
       }
     },
     "@storybook/addon-knobs": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-knobs/-/addon-knobs-5.2.1.tgz",
-      "integrity": "sha512-JCSqrGYyVVBNkudhvla7qc9m0/Mn1UMaMzIxH5kewEE1KWZcCkdXD5hDASN39pkn3mX1yyqveP8jiyIL9vVBLg==",
+      "version": "6.0.21",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/addon-knobs/-/addon-knobs-6.0.21.tgz",
+      "integrity": "sha512-QHcdL08wGzw67Igpow3wCHWq0WfG5E/q7EFwOwTvr4X3s8VBjuauVdWolcX1/N+z2U7m31rcD6tcMBMPjUibmw==",
       "requires": {
-        "@storybook/addons": "5.2.1",
-        "@storybook/api": "5.2.1",
-        "@storybook/client-api": "5.2.1",
-        "@storybook/components": "5.2.1",
-        "@storybook/core-events": "5.2.1",
-        "@storybook/theming": "5.2.1",
+        "@storybook/addons": "6.0.21",
+        "@storybook/api": "6.0.21",
+        "@storybook/channels": "6.0.21",
+        "@storybook/client-api": "6.0.21",
+        "@storybook/components": "6.0.21",
+        "@storybook/core-events": "6.0.21",
+        "@storybook/theming": "6.0.21",
         "copy-to-clipboard": "^3.0.8",
         "core-js": "^3.0.1",
         "escape-html": "^1.0.3",
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "global": "^4.3.2",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "prop-types": "^15.7.2",
         "qs": "^6.6.0",
         "react-color": "^2.17.0",
         "react-lifecycles-compat": "^3.0.4",
-        "react-select": "^3.0.0"
+        "react-select": "^3.0.8",
+        "regenerator-runtime": "^0.13.3"
       },
       "dependencies": {
         "@storybook/addons": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.2.1.tgz",
-          "integrity": "sha512-kdx97tTKsMf/lBlT40uLYsHMF1J71mn2j41RNaCXmWw/PrKCDmiNfinemN2wtbwRSvGqb3q/BAqjKLvUtWynGg==",
+          "version": "6.0.21",
+          "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/addons/-/addons-6.0.21.tgz",
+          "integrity": "sha512-yDttNLc3vXqBxwK795ykgzTC6MpvuXDQuF4LHSlHZQe6wsMu1m3fljnbYdafJWdx6cNZwUblU3KYcR11PqhkPg==",
           "requires": {
-            "@storybook/api": "5.2.1",
-            "@storybook/channels": "5.2.1",
-            "@storybook/client-logger": "5.2.1",
-            "@storybook/core-events": "5.2.1",
+            "@storybook/api": "6.0.21",
+            "@storybook/channels": "6.0.21",
+            "@storybook/client-logger": "6.0.21",
+            "@storybook/core-events": "6.0.21",
+            "@storybook/router": "6.0.21",
+            "@storybook/theming": "6.0.21",
             "core-js": "^3.0.1",
             "global": "^4.3.2",
-            "util-deprecate": "^1.0.2"
+            "regenerator-runtime": "^0.13.3"
           }
         },
         "@storybook/api": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.2.1.tgz",
-          "integrity": "sha512-EXN6sqkGHRuNq0W6BZXOlxe2I2dmN0yUdQLiUOpzH2I3mXnVHpad/0v76dRc9fZbC4LaYUSxR8lBTr0rqIb4mA==",
+          "version": "6.0.21",
+          "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/api/-/api-6.0.21.tgz",
+          "integrity": "sha512-cRRGf/KGFwYiDouTouEcDdp45N1AbYnAfvLqYZ3KuUTGZ+CiU/PN/vavkp07DQeM4FIQO8TLhzHdsLFpLT7Lkw==",
           "requires": {
-            "@storybook/channels": "5.2.1",
-            "@storybook/client-logger": "5.2.1",
-            "@storybook/core-events": "5.2.1",
-            "@storybook/router": "5.2.1",
-            "@storybook/theming": "5.2.1",
+            "@reach/router": "^1.3.3",
+            "@storybook/channels": "6.0.21",
+            "@storybook/client-logger": "6.0.21",
+            "@storybook/core-events": "6.0.21",
+            "@storybook/csf": "0.0.1",
+            "@storybook/router": "6.0.21",
+            "@storybook/semver": "^7.3.2",
+            "@storybook/theming": "6.0.21",
+            "@types/reach__router": "^1.3.5",
             "core-js": "^3.0.1",
-            "fast-deep-equal": "^2.0.1",
+            "fast-deep-equal": "^3.1.1",
             "global": "^4.3.2",
-            "lodash": "^4.17.11",
+            "lodash": "^4.17.15",
             "memoizerific": "^1.11.3",
-            "prop-types": "^15.6.2",
             "react": "^16.8.3",
-            "semver": "^6.0.0",
-            "shallow-equal": "^1.1.0",
+            "regenerator-runtime": "^0.13.3",
             "store2": "^2.7.1",
-            "telejson": "^2.2.2",
+            "telejson": "^5.0.2",
+            "ts-dedent": "^1.1.1",
             "util-deprecate": "^1.0.2"
-          },
-          "dependencies": {
-            "react": {
-              "version": "16.13.0",
-              "resolved": "https://registry.npmjs.org/react/-/react-16.13.0.tgz",
-              "integrity": "sha512-TSavZz2iSLkq5/oiE7gnFzmURKZMltmi193rm5HEoUDAXpzT9Kzw6oNZnGoai/4+fUnm7FqS5dwgUL34TujcWQ==",
-              "requires": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2"
-              }
-            }
           }
         },
         "@storybook/channels": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.2.1.tgz",
-          "integrity": "sha512-AsF/Hwx91SDOgiOGOBSWS8EJAgqVm939n2nkfdLSJQQmX5EdPRAc3EIE3f13tyQub2yNx0OR4UzQDWgjwfVsEQ==",
+          "version": "6.0.21",
+          "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/channels/-/channels-6.0.21.tgz",
+          "integrity": "sha512-G6gjcEotSwDmOlxSmOMgsO3VhQ42RLJK7kFp6D5eg0Q6S8vsypltdT8orxdu+6+AbcBrL+5Sla8lThzaCvXsVQ==",
           "requires": {
-            "core-js": "^3.0.1"
+            "core-js": "^3.0.1",
+            "ts-dedent": "^1.1.1",
+            "util-deprecate": "^1.0.2"
           }
         },
         "@storybook/client-logger": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.2.1.tgz",
-          "integrity": "sha512-wzxSE9t3DaLCdd/gnGFnjevmYRZ92F3TEwhUP/QDXM9cZkNsRKHkjE61qjiO5aQPaZQG6Ea9ayWEQEMgZXDucg==",
+          "version": "6.0.21",
+          "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/client-logger/-/client-logger-6.0.21.tgz",
+          "integrity": "sha512-8aUEbhjXV+UMYQWukVYnp+kZafF+LD4Dm7eMo37IUZvt3VIjV1VvhxIDVJtqjk2vv0KZTepESFBkZQLmBzI9Zg==",
           "requires": {
-            "core-js": "^3.0.1"
+            "core-js": "^3.0.1",
+            "global": "^4.3.2"
           }
         },
         "@storybook/components": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-5.2.1.tgz",
-          "integrity": "sha512-cik5J/mTm1b1TOI17qM+2Mikk3rjb3SbBD4WlNz3Zvn+Hw0ukgbx6kQwVBgujhMlDtsHreidyEgIg4TM13S0Tg==",
+          "version": "6.0.21",
+          "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/components/-/components-6.0.21.tgz",
+          "integrity": "sha512-r6btqFW/rcXIU5v231EifZfdh9O0fy7bJDXwwDf8zVUgLx8JRc0VnSs3nvK3Is9HF1wZ9vjx/7Lh4rTIDZAjgg==",
           "requires": {
-            "@storybook/client-logger": "5.2.1",
-            "@storybook/theming": "5.2.1",
-            "@types/react-syntax-highlighter": "10.1.0",
+            "@storybook/client-logger": "6.0.21",
+            "@storybook/csf": "0.0.1",
+            "@storybook/theming": "6.0.21",
+            "@types/overlayscrollbars": "^1.9.0",
+            "@types/react-color": "^3.0.1",
+            "@types/react-syntax-highlighter": "11.0.4",
             "core-js": "^3.0.1",
+            "fast-deep-equal": "^3.1.1",
             "global": "^4.3.2",
-            "markdown-to-jsx": "^6.9.1",
+            "lodash": "^4.17.15",
+            "markdown-to-jsx": "^6.11.4",
             "memoizerific": "^1.11.3",
-            "polished": "^3.3.1",
+            "overlayscrollbars": "^1.10.2",
+            "polished": "^3.4.4",
             "popper.js": "^1.14.7",
-            "prop-types": "^15.7.2",
             "react": "^16.8.3",
+            "react-color": "^2.17.0",
             "react-dom": "^16.8.3",
-            "react-focus-lock": "^1.18.3",
-            "react-helmet-async": "^1.0.2",
-            "react-popper-tooltip": "^2.8.3",
-            "react-syntax-highlighter": "^8.0.1",
-            "react-textarea-autosize": "^7.1.0",
-            "simplebar-react": "^1.0.0-alpha.6"
-          },
-          "dependencies": {
-            "react": {
-              "version": "16.13.0",
-              "resolved": "https://registry.npmjs.org/react/-/react-16.13.0.tgz",
-              "integrity": "sha512-TSavZz2iSLkq5/oiE7gnFzmURKZMltmi193rm5HEoUDAXpzT9Kzw6oNZnGoai/4+fUnm7FqS5dwgUL34TujcWQ==",
-              "requires": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2"
-              }
-            }
+            "react-popper-tooltip": "^2.11.0",
+            "react-syntax-highlighter": "^12.2.1",
+            "react-textarea-autosize": "^8.1.1",
+            "ts-dedent": "^1.1.1"
           }
         },
         "@storybook/core-events": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.2.1.tgz",
-          "integrity": "sha512-AIYV/I+baQ0KxvEM7QAKqUedLn2os0XU9HTdtfZJTC3U9wjmR2ah2ScD6T0n7PBz3MderkvZG6dNjs9h8gRquQ==",
+          "version": "6.0.21",
+          "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/core-events/-/core-events-6.0.21.tgz",
+          "integrity": "sha512-p84fbPcsAhnqDhp+HJ4P8+vI2BqJus4IRoVAemLAwuPjyPElrV9UvOa/RHy1BN8Z6jXwFA+FFzfGl2kPJ3WYcA==",
           "requires": {
             "core-js": "^3.0.1"
           }
         },
         "@storybook/router": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.2.1.tgz",
-          "integrity": "sha512-Mlk275cyPoKtnP4DwQ5D8gTfnaRPL6kDZOSn0wbTMa6pQOfYKgJsa7tjzeAtZuZ/j8hKI4gAfT/auMgH6g+94A==",
+          "version": "6.0.21",
+          "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/router/-/router-6.0.21.tgz",
+          "integrity": "sha512-46SsKJfcd12lRrISnfrWhicJx8EylkgGDGohfH0n5p7inkkGOkKV8QFZoYPRKZueMXmUKpzJ0Z3HmVsLTCrCDw==",
           "requires": {
-            "@reach/router": "^1.2.1",
-            "@types/reach__router": "^1.2.3",
+            "@reach/router": "^1.3.3",
+            "@types/reach__router": "^1.3.5",
             "core-js": "^3.0.1",
             "global": "^4.3.2",
-            "lodash": "^4.17.11",
             "memoizerific": "^1.11.3",
             "qs": "^6.6.0"
           }
         },
-        "@storybook/theming": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.2.1.tgz",
-          "integrity": "sha512-lbAfcyI7Tx8swduIPmlu/jdWzqTBN/v82IEQbZbPR4LS5OHRPmhXPNgFGrcH4kFAiD0GoezSsdum1x0ZZpsQUQ==",
+        "@storybook/semver": {
+          "version": "7.3.2",
+          "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-SWeszlsiPsMI0Ps0jVNtH64cI5c0UF3f7KgjVKJoNP30crQ6wUSddY2hsdeczZXEKVJGEn50Q60flcGsQGIcrg==",
           "requires": {
-            "@emotion/core": "^10.0.14",
-            "@emotion/styled": "^10.0.14",
-            "@storybook/client-logger": "5.2.1",
-            "common-tags": "^1.8.0",
-            "core-js": "^3.0.1",
-            "deep-object-diff": "^1.1.0",
-            "emotion-theming": "^10.0.14",
-            "global": "^4.3.2",
-            "memoizerific": "^1.11.3",
-            "polished": "^3.3.1",
-            "prop-types": "^15.7.2",
-            "resolve-from": "^5.0.0"
+            "core-js": "^3.6.5",
+            "find-up": "^4.1.0"
           }
         },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        "@storybook/theming": {
+          "version": "6.0.21",
+          "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/theming/-/theming-6.0.21.tgz",
+          "integrity": "sha512-n97DfB9kG6WrV1xBGDyeQibTrh8pBBCp3dSL3UTGH+KX3C2+4sm6QHlTgyekbi5FrbFEbnuZOKAS3YbLVONsRQ==",
+          "requires": {
+            "@emotion/core": "^10.0.20",
+            "@emotion/is-prop-valid": "^0.8.6",
+            "@emotion/styled": "^10.0.17",
+            "@storybook/client-logger": "6.0.21",
+            "core-js": "^3.0.1",
+            "deep-object-diff": "^1.1.0",
+            "emotion-theming": "^10.0.19",
+            "global": "^4.3.2",
+            "memoizerific": "^1.11.3",
+            "polished": "^3.4.4",
+            "resolve-from": "^5.0.0",
+            "ts-dedent": "^1.1.1"
+          }
         },
         "telejson": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/telejson/-/telejson-2.2.2.tgz",
-          "integrity": "sha512-YyNwnKY0ilabOwYgC/J754En1xOe5PBIUIw+C9e0+5HjVVcnQE5/gdu2yET2pmSbp5bxIDqYNjvndj2PUkIiYA==",
+          "version": "5.0.2",
+          "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/telejson/-/telejson-5.0.2.tgz",
+          "integrity": "sha512-XCrDHGbinczsscs8LXFr9jDhvy37yBk9piB7FJrCfxE8oP66WDkolNMpaBkWYgQqB9dQGBGtTDzGQPedc9KJmw==",
           "requires": {
-            "global": "^4.3.2",
-            "is-function": "^1.0.1",
-            "is-regex": "^1.0.4",
-            "is-symbol": "^1.0.2",
-            "isobject": "^3.0.1",
-            "lodash": "^4.17.11",
+            "@types/is-function": "^1.0.0",
+            "global": "^4.4.0",
+            "is-function": "^1.0.2",
+            "is-regex": "^1.1.1",
+            "is-symbol": "^1.0.3",
+            "isobject": "^4.0.0",
+            "lodash": "^4.17.19",
             "memoizerific": "^1.11.3"
+          },
+          "dependencies": {
+            "lodash": {
+              "version": "4.17.20",
+              "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+            }
           }
         }
       }
     },
     "@storybook/addons": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.2.6.tgz",
-      "integrity": "sha512-5MF64lsAhIEMxTbVpYROz5Wez595iwSw45yXyP8gWt12d+EmFO5tdy7cYJCxcMuVhDfaCI78tFqS9orr1atVyA==",
+      "version": "6.0.21",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/addons/-/addons-6.0.21.tgz",
+      "integrity": "sha512-yDttNLc3vXqBxwK795ykgzTC6MpvuXDQuF4LHSlHZQe6wsMu1m3fljnbYdafJWdx6cNZwUblU3KYcR11PqhkPg==",
       "dev": true,
       "requires": {
-        "@storybook/api": "5.2.6",
-        "@storybook/channels": "5.2.6",
-        "@storybook/client-logger": "5.2.6",
-        "@storybook/core-events": "5.2.6",
+        "@storybook/api": "6.0.21",
+        "@storybook/channels": "6.0.21",
+        "@storybook/client-logger": "6.0.21",
+        "@storybook/core-events": "6.0.21",
+        "@storybook/router": "6.0.21",
+        "@storybook/theming": "6.0.21",
         "core-js": "^3.0.1",
         "global": "^4.3.2",
-        "util-deprecate": "^1.0.2"
+        "regenerator-runtime": "^0.13.3"
       }
     },
     "@storybook/api": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.2.6.tgz",
-      "integrity": "sha512-X/di44/SAL68mD6RHTX2qdWwhjRW6BgcfPtu0dMd38ErB3AfsfP4BITXs6kFOeSM8kWiaQoyuw0pOBzA8vlYug==",
+      "version": "6.0.21",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/api/-/api-6.0.21.tgz",
+      "integrity": "sha512-cRRGf/KGFwYiDouTouEcDdp45N1AbYnAfvLqYZ3KuUTGZ+CiU/PN/vavkp07DQeM4FIQO8TLhzHdsLFpLT7Lkw==",
       "dev": true,
       "requires": {
-        "@storybook/channels": "5.2.6",
-        "@storybook/client-logger": "5.2.6",
-        "@storybook/core-events": "5.2.6",
-        "@storybook/router": "5.2.6",
-        "@storybook/theming": "5.2.6",
+        "@reach/router": "^1.3.3",
+        "@storybook/channels": "6.0.21",
+        "@storybook/client-logger": "6.0.21",
+        "@storybook/core-events": "6.0.21",
+        "@storybook/csf": "0.0.1",
+        "@storybook/router": "6.0.21",
+        "@storybook/semver": "^7.3.2",
+        "@storybook/theming": "6.0.21",
+        "@types/reach__router": "^1.3.5",
         "core-js": "^3.0.1",
-        "fast-deep-equal": "^2.0.1",
+        "fast-deep-equal": "^3.1.1",
         "global": "^4.3.2",
         "lodash": "^4.17.15",
         "memoizerific": "^1.11.3",
-        "prop-types": "^15.6.2",
         "react": "^16.8.3",
-        "semver": "^6.0.0",
-        "shallow-equal": "^1.1.0",
+        "regenerator-runtime": "^0.13.3",
         "store2": "^2.7.1",
-        "telejson": "^3.0.2",
+        "telejson": "^5.0.2",
+        "ts-dedent": "^1.1.1",
         "util-deprecate": "^1.0.2"
       },
       "dependencies": {
-        "react": {
-          "version": "16.13.0",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.13.0.tgz",
-          "integrity": "sha512-TSavZz2iSLkq5/oiE7gnFzmURKZMltmi193rm5HEoUDAXpzT9Kzw6oNZnGoai/4+fUnm7FqS5dwgUL34TujcWQ==",
+        "@storybook/semver": {
+          "version": "7.3.2",
+          "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-SWeszlsiPsMI0Ps0jVNtH64cI5c0UF3f7KgjVKJoNP30crQ6wUSddY2hsdeczZXEKVJGEn50Q60flcGsQGIcrg==",
           "dev": true,
           "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2"
+            "core-js": "^3.6.5",
+            "find-up": "^4.1.0"
           }
         }
       }
     },
     "@storybook/channel-postmessage": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-5.2.1.tgz",
-      "integrity": "sha512-gmnn9qU1iLCpfF6bZuEM3QQOZsAviWeIpiezjrd/qkxatgr3qtbXd4EoZpcVuQw314etarWtNxVpcX6PXcASjQ==",
+      "version": "6.0.21",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/channel-postmessage/-/channel-postmessage-6.0.21.tgz",
+      "integrity": "sha512-ArRnoaS+b7qpAku/SO27z/yjRDCXb37mCPYGX0ntPbiQajootUbGO7otfnjFkaP44hCEC9uDYlOfMU1hYU1N6A==",
       "requires": {
-        "@storybook/channels": "5.2.1",
-        "@storybook/client-logger": "5.2.1",
+        "@storybook/channels": "6.0.21",
+        "@storybook/client-logger": "6.0.21",
+        "@storybook/core-events": "6.0.21",
         "core-js": "^3.0.1",
         "global": "^4.3.2",
-        "telejson": "^2.2.2"
+        "qs": "^6.6.0",
+        "telejson": "^5.0.2"
       },
       "dependencies": {
         "@storybook/channels": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.2.1.tgz",
-          "integrity": "sha512-AsF/Hwx91SDOgiOGOBSWS8EJAgqVm939n2nkfdLSJQQmX5EdPRAc3EIE3f13tyQub2yNx0OR4UzQDWgjwfVsEQ==",
+          "version": "6.0.21",
+          "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/channels/-/channels-6.0.21.tgz",
+          "integrity": "sha512-G6gjcEotSwDmOlxSmOMgsO3VhQ42RLJK7kFp6D5eg0Q6S8vsypltdT8orxdu+6+AbcBrL+5Sla8lThzaCvXsVQ==",
           "requires": {
-            "core-js": "^3.0.1"
+            "core-js": "^3.0.1",
+            "ts-dedent": "^1.1.1",
+            "util-deprecate": "^1.0.2"
           }
         },
         "@storybook/client-logger": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.2.1.tgz",
-          "integrity": "sha512-wzxSE9t3DaLCdd/gnGFnjevmYRZ92F3TEwhUP/QDXM9cZkNsRKHkjE61qjiO5aQPaZQG6Ea9ayWEQEMgZXDucg==",
+          "version": "6.0.21",
+          "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/client-logger/-/client-logger-6.0.21.tgz",
+          "integrity": "sha512-8aUEbhjXV+UMYQWukVYnp+kZafF+LD4Dm7eMo37IUZvt3VIjV1VvhxIDVJtqjk2vv0KZTepESFBkZQLmBzI9Zg==",
+          "requires": {
+            "core-js": "^3.0.1",
+            "global": "^4.3.2"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "6.0.21",
+          "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/core-events/-/core-events-6.0.21.tgz",
+          "integrity": "sha512-p84fbPcsAhnqDhp+HJ4P8+vI2BqJus4IRoVAemLAwuPjyPElrV9UvOa/RHy1BN8Z6jXwFA+FFzfGl2kPJ3WYcA==",
           "requires": {
             "core-js": "^3.0.1"
           }
         },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
         },
         "telejson": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/telejson/-/telejson-2.2.2.tgz",
-          "integrity": "sha512-YyNwnKY0ilabOwYgC/J754En1xOe5PBIUIw+C9e0+5HjVVcnQE5/gdu2yET2pmSbp5bxIDqYNjvndj2PUkIiYA==",
+          "version": "5.0.2",
+          "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/telejson/-/telejson-5.0.2.tgz",
+          "integrity": "sha512-XCrDHGbinczsscs8LXFr9jDhvy37yBk9piB7FJrCfxE8oP66WDkolNMpaBkWYgQqB9dQGBGtTDzGQPedc9KJmw==",
           "requires": {
-            "global": "^4.3.2",
-            "is-function": "^1.0.1",
-            "is-regex": "^1.0.4",
-            "is-symbol": "^1.0.2",
-            "isobject": "^3.0.1",
-            "lodash": "^4.17.11",
+            "@types/is-function": "^1.0.0",
+            "global": "^4.4.0",
+            "is-function": "^1.0.2",
+            "is-regex": "^1.1.1",
+            "is-symbol": "^1.0.3",
+            "isobject": "^4.0.0",
+            "lodash": "^4.17.19",
             "memoizerific": "^1.11.3"
           }
         }
       }
     },
     "@storybook/channels": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.2.6.tgz",
-      "integrity": "sha512-/UsktYsXuvb1efjVPCEivhh5ywRhm7hl73pQnpJLJHRqyLMM2I5nGPFELTTNuU9yWy7sP9QL5gRqBBPe1sqjZQ==",
+      "version": "6.0.21",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/channels/-/channels-6.0.21.tgz",
+      "integrity": "sha512-G6gjcEotSwDmOlxSmOMgsO3VhQ42RLJK7kFp6D5eg0Q6S8vsypltdT8orxdu+6+AbcBrL+5Sla8lThzaCvXsVQ==",
       "dev": true,
       "requires": {
-        "core-js": "^3.0.1"
+        "core-js": "^3.0.1",
+        "ts-dedent": "^1.1.1",
+        "util-deprecate": "^1.0.2"
       }
     },
     "@storybook/client-api": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-5.2.1.tgz",
-      "integrity": "sha512-VxexqxrbORCGqwx2j0/91Eu1A/vq+rSVIesWwzIowmoLfBwRwDdskO20Yn9U7iMSpux4RvHGF6y1Q1ZtnXm9aA==",
+      "version": "6.0.21",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/client-api/-/client-api-6.0.21.tgz",
+      "integrity": "sha512-emBXd/ml6pc3G8gP3MsR9zQsAq1zZbqof9MxB51tG/jpTXdqWQ8ce1pt1tJS8Xj0QDM072jR6wsY+mmro0GZnA==",
       "requires": {
-        "@storybook/addons": "5.2.1",
-        "@storybook/channel-postmessage": "5.2.1",
-        "@storybook/channels": "5.2.1",
-        "@storybook/client-logger": "5.2.1",
-        "@storybook/core-events": "5.2.1",
-        "@storybook/router": "5.2.1",
-        "common-tags": "^1.8.0",
+        "@storybook/addons": "6.0.21",
+        "@storybook/channel-postmessage": "6.0.21",
+        "@storybook/channels": "6.0.21",
+        "@storybook/client-logger": "6.0.21",
+        "@storybook/core-events": "6.0.21",
+        "@storybook/csf": "0.0.1",
+        "@types/qs": "^6.9.0",
+        "@types/webpack-env": "^1.15.2",
         "core-js": "^3.0.1",
-        "eventemitter3": "^4.0.0",
         "global": "^4.3.2",
-        "is-plain-object": "^3.0.0",
-        "lodash": "^4.17.11",
+        "lodash": "^4.17.15",
         "memoizerific": "^1.11.3",
         "qs": "^6.6.0",
+        "stable": "^0.1.8",
+        "store2": "^2.7.1",
+        "ts-dedent": "^1.1.1",
         "util-deprecate": "^1.0.2"
       },
       "dependencies": {
         "@storybook/addons": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.2.1.tgz",
-          "integrity": "sha512-kdx97tTKsMf/lBlT40uLYsHMF1J71mn2j41RNaCXmWw/PrKCDmiNfinemN2wtbwRSvGqb3q/BAqjKLvUtWynGg==",
+          "version": "6.0.21",
+          "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/addons/-/addons-6.0.21.tgz",
+          "integrity": "sha512-yDttNLc3vXqBxwK795ykgzTC6MpvuXDQuF4LHSlHZQe6wsMu1m3fljnbYdafJWdx6cNZwUblU3KYcR11PqhkPg==",
           "requires": {
-            "@storybook/api": "5.2.1",
-            "@storybook/channels": "5.2.1",
-            "@storybook/client-logger": "5.2.1",
-            "@storybook/core-events": "5.2.1",
+            "@storybook/api": "6.0.21",
+            "@storybook/channels": "6.0.21",
+            "@storybook/client-logger": "6.0.21",
+            "@storybook/core-events": "6.0.21",
+            "@storybook/router": "6.0.21",
+            "@storybook/theming": "6.0.21",
             "core-js": "^3.0.1",
             "global": "^4.3.2",
-            "util-deprecate": "^1.0.2"
+            "regenerator-runtime": "^0.13.3"
           }
         },
         "@storybook/api": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.2.1.tgz",
-          "integrity": "sha512-EXN6sqkGHRuNq0W6BZXOlxe2I2dmN0yUdQLiUOpzH2I3mXnVHpad/0v76dRc9fZbC4LaYUSxR8lBTr0rqIb4mA==",
+          "version": "6.0.21",
+          "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/api/-/api-6.0.21.tgz",
+          "integrity": "sha512-cRRGf/KGFwYiDouTouEcDdp45N1AbYnAfvLqYZ3KuUTGZ+CiU/PN/vavkp07DQeM4FIQO8TLhzHdsLFpLT7Lkw==",
           "requires": {
-            "@storybook/channels": "5.2.1",
-            "@storybook/client-logger": "5.2.1",
-            "@storybook/core-events": "5.2.1",
-            "@storybook/router": "5.2.1",
-            "@storybook/theming": "5.2.1",
+            "@reach/router": "^1.3.3",
+            "@storybook/channels": "6.0.21",
+            "@storybook/client-logger": "6.0.21",
+            "@storybook/core-events": "6.0.21",
+            "@storybook/csf": "0.0.1",
+            "@storybook/router": "6.0.21",
+            "@storybook/semver": "^7.3.2",
+            "@storybook/theming": "6.0.21",
+            "@types/reach__router": "^1.3.5",
             "core-js": "^3.0.1",
-            "fast-deep-equal": "^2.0.1",
+            "fast-deep-equal": "^3.1.1",
             "global": "^4.3.2",
-            "lodash": "^4.17.11",
+            "lodash": "^4.17.15",
             "memoizerific": "^1.11.3",
-            "prop-types": "^15.6.2",
             "react": "^16.8.3",
-            "semver": "^6.0.0",
-            "shallow-equal": "^1.1.0",
+            "regenerator-runtime": "^0.13.3",
             "store2": "^2.7.1",
-            "telejson": "^2.2.2",
+            "telejson": "^5.0.2",
+            "ts-dedent": "^1.1.1",
             "util-deprecate": "^1.0.2"
-          },
-          "dependencies": {
-            "react": {
-              "version": "16.13.0",
-              "resolved": "https://registry.npmjs.org/react/-/react-16.13.0.tgz",
-              "integrity": "sha512-TSavZz2iSLkq5/oiE7gnFzmURKZMltmi193rm5HEoUDAXpzT9Kzw6oNZnGoai/4+fUnm7FqS5dwgUL34TujcWQ==",
-              "requires": {
-                "loose-envify": "^1.1.0",
-                "object-assign": "^4.1.1",
-                "prop-types": "^15.6.2"
-              }
-            }
           }
         },
         "@storybook/channels": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.2.1.tgz",
-          "integrity": "sha512-AsF/Hwx91SDOgiOGOBSWS8EJAgqVm939n2nkfdLSJQQmX5EdPRAc3EIE3f13tyQub2yNx0OR4UzQDWgjwfVsEQ==",
+          "version": "6.0.21",
+          "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/channels/-/channels-6.0.21.tgz",
+          "integrity": "sha512-G6gjcEotSwDmOlxSmOMgsO3VhQ42RLJK7kFp6D5eg0Q6S8vsypltdT8orxdu+6+AbcBrL+5Sla8lThzaCvXsVQ==",
           "requires": {
-            "core-js": "^3.0.1"
+            "core-js": "^3.0.1",
+            "ts-dedent": "^1.1.1",
+            "util-deprecate": "^1.0.2"
           }
         },
         "@storybook/client-logger": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.2.1.tgz",
-          "integrity": "sha512-wzxSE9t3DaLCdd/gnGFnjevmYRZ92F3TEwhUP/QDXM9cZkNsRKHkjE61qjiO5aQPaZQG6Ea9ayWEQEMgZXDucg==",
+          "version": "6.0.21",
+          "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/client-logger/-/client-logger-6.0.21.tgz",
+          "integrity": "sha512-8aUEbhjXV+UMYQWukVYnp+kZafF+LD4Dm7eMo37IUZvt3VIjV1VvhxIDVJtqjk2vv0KZTepESFBkZQLmBzI9Zg==",
           "requires": {
-            "core-js": "^3.0.1"
+            "core-js": "^3.0.1",
+            "global": "^4.3.2"
           }
         },
         "@storybook/core-events": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.2.1.tgz",
-          "integrity": "sha512-AIYV/I+baQ0KxvEM7QAKqUedLn2os0XU9HTdtfZJTC3U9wjmR2ah2ScD6T0n7PBz3MderkvZG6dNjs9h8gRquQ==",
+          "version": "6.0.21",
+          "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/core-events/-/core-events-6.0.21.tgz",
+          "integrity": "sha512-p84fbPcsAhnqDhp+HJ4P8+vI2BqJus4IRoVAemLAwuPjyPElrV9UvOa/RHy1BN8Z6jXwFA+FFzfGl2kPJ3WYcA==",
           "requires": {
             "core-js": "^3.0.1"
           }
         },
         "@storybook/router": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.2.1.tgz",
-          "integrity": "sha512-Mlk275cyPoKtnP4DwQ5D8gTfnaRPL6kDZOSn0wbTMa6pQOfYKgJsa7tjzeAtZuZ/j8hKI4gAfT/auMgH6g+94A==",
+          "version": "6.0.21",
+          "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/router/-/router-6.0.21.tgz",
+          "integrity": "sha512-46SsKJfcd12lRrISnfrWhicJx8EylkgGDGohfH0n5p7inkkGOkKV8QFZoYPRKZueMXmUKpzJ0Z3HmVsLTCrCDw==",
           "requires": {
-            "@reach/router": "^1.2.1",
-            "@types/reach__router": "^1.2.3",
+            "@reach/router": "^1.3.3",
+            "@types/reach__router": "^1.3.5",
             "core-js": "^3.0.1",
             "global": "^4.3.2",
-            "lodash": "^4.17.11",
             "memoizerific": "^1.11.3",
             "qs": "^6.6.0"
           }
         },
-        "@storybook/theming": {
-          "version": "5.2.1",
-          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.2.1.tgz",
-          "integrity": "sha512-lbAfcyI7Tx8swduIPmlu/jdWzqTBN/v82IEQbZbPR4LS5OHRPmhXPNgFGrcH4kFAiD0GoezSsdum1x0ZZpsQUQ==",
+        "@storybook/semver": {
+          "version": "7.3.2",
+          "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-SWeszlsiPsMI0Ps0jVNtH64cI5c0UF3f7KgjVKJoNP30crQ6wUSddY2hsdeczZXEKVJGEn50Q60flcGsQGIcrg==",
           "requires": {
-            "@emotion/core": "^10.0.14",
-            "@emotion/styled": "^10.0.14",
-            "@storybook/client-logger": "5.2.1",
-            "common-tags": "^1.8.0",
-            "core-js": "^3.0.1",
-            "deep-object-diff": "^1.1.0",
-            "emotion-theming": "^10.0.14",
-            "global": "^4.3.2",
-            "memoizerific": "^1.11.3",
-            "polished": "^3.3.1",
-            "prop-types": "^15.7.2",
-            "resolve-from": "^5.0.0"
+            "core-js": "^3.6.5",
+            "find-up": "^4.1.0"
           }
         },
-        "isobject": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+        "@storybook/theming": {
+          "version": "6.0.21",
+          "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/theming/-/theming-6.0.21.tgz",
+          "integrity": "sha512-n97DfB9kG6WrV1xBGDyeQibTrh8pBBCp3dSL3UTGH+KX3C2+4sm6QHlTgyekbi5FrbFEbnuZOKAS3YbLVONsRQ==",
+          "requires": {
+            "@emotion/core": "^10.0.20",
+            "@emotion/is-prop-valid": "^0.8.6",
+            "@emotion/styled": "^10.0.17",
+            "@storybook/client-logger": "6.0.21",
+            "core-js": "^3.0.1",
+            "deep-object-diff": "^1.1.0",
+            "emotion-theming": "^10.0.19",
+            "global": "^4.3.2",
+            "memoizerific": "^1.11.3",
+            "polished": "^3.4.4",
+            "resolve-from": "^5.0.0",
+            "ts-dedent": "^1.1.1"
+          }
         },
         "telejson": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/telejson/-/telejson-2.2.2.tgz",
-          "integrity": "sha512-YyNwnKY0ilabOwYgC/J754En1xOe5PBIUIw+C9e0+5HjVVcnQE5/gdu2yET2pmSbp5bxIDqYNjvndj2PUkIiYA==",
+          "version": "5.0.2",
+          "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/telejson/-/telejson-5.0.2.tgz",
+          "integrity": "sha512-XCrDHGbinczsscs8LXFr9jDhvy37yBk9piB7FJrCfxE8oP66WDkolNMpaBkWYgQqB9dQGBGtTDzGQPedc9KJmw==",
           "requires": {
-            "global": "^4.3.2",
-            "is-function": "^1.0.1",
-            "is-regex": "^1.0.4",
-            "is-symbol": "^1.0.2",
-            "isobject": "^3.0.1",
-            "lodash": "^4.17.11",
+            "@types/is-function": "^1.0.0",
+            "global": "^4.4.0",
+            "is-function": "^1.0.2",
+            "is-regex": "^1.1.1",
+            "is-symbol": "^1.0.3",
+            "isobject": "^4.0.0",
+            "lodash": "^4.17.19",
             "memoizerific": "^1.11.3"
+          },
+          "dependencies": {
+            "lodash": {
+              "version": "4.17.20",
+              "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/lodash/-/lodash-4.17.20.tgz",
+              "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+            }
           }
         }
       }
     },
     "@storybook/client-logger": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.2.6.tgz",
-      "integrity": "sha512-hJvPD267cCwLIRMOISjDH8h9wbwOcXIJip29UlJbU9iMtZtgE+YelmlpmZJvqcDfUiXWWrOh7tP76mj8EAfwIQ==",
+      "version": "6.0.21",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/client-logger/-/client-logger-6.0.21.tgz",
+      "integrity": "sha512-8aUEbhjXV+UMYQWukVYnp+kZafF+LD4Dm7eMo37IUZvt3VIjV1VvhxIDVJtqjk2vv0KZTepESFBkZQLmBzI9Zg==",
       "dev": true,
       "requires": {
-        "core-js": "^3.0.1"
+        "core-js": "^3.0.1",
+        "global": "^4.3.2"
       }
     },
     "@storybook/components": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-5.2.6.tgz",
-      "integrity": "sha512-C7OS90bZ1ZvxlWUZ3B2MPFFggqAtUo7X8DqqS3IwsuDUiK9dD/KS0MwPgOuFDnOTW1R5XqmQd/ylt53w3s/U5g==",
+      "version": "6.0.21",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/components/-/components-6.0.21.tgz",
+      "integrity": "sha512-r6btqFW/rcXIU5v231EifZfdh9O0fy7bJDXwwDf8zVUgLx8JRc0VnSs3nvK3Is9HF1wZ9vjx/7Lh4rTIDZAjgg==",
       "dev": true,
       "requires": {
-        "@storybook/client-logger": "5.2.6",
-        "@storybook/theming": "5.2.6",
-        "@types/react-syntax-highlighter": "10.1.0",
-        "@types/react-textarea-autosize": "^4.3.3",
+        "@storybook/client-logger": "6.0.21",
+        "@storybook/csf": "0.0.1",
+        "@storybook/theming": "6.0.21",
+        "@types/overlayscrollbars": "^1.9.0",
+        "@types/react-color": "^3.0.1",
+        "@types/react-syntax-highlighter": "11.0.4",
         "core-js": "^3.0.1",
+        "fast-deep-equal": "^3.1.1",
         "global": "^4.3.2",
-        "markdown-to-jsx": "^6.9.1",
+        "lodash": "^4.17.15",
+        "markdown-to-jsx": "^6.11.4",
         "memoizerific": "^1.11.3",
-        "polished": "^3.3.1",
+        "overlayscrollbars": "^1.10.2",
+        "polished": "^3.4.4",
         "popper.js": "^1.14.7",
-        "prop-types": "^15.7.2",
         "react": "^16.8.3",
+        "react-color": "^2.17.0",
         "react-dom": "^16.8.3",
-        "react-focus-lock": "^1.18.3",
-        "react-helmet-async": "^1.0.2",
-        "react-popper-tooltip": "^2.8.3",
-        "react-syntax-highlighter": "^8.0.1",
-        "react-textarea-autosize": "^7.1.0",
-        "simplebar-react": "^1.0.0-alpha.6"
-      },
-      "dependencies": {
-        "react": {
-          "version": "16.13.0",
-          "resolved": "https://registry.npmjs.org/react/-/react-16.13.0.tgz",
-          "integrity": "sha512-TSavZz2iSLkq5/oiE7gnFzmURKZMltmi193rm5HEoUDAXpzT9Kzw6oNZnGoai/4+fUnm7FqS5dwgUL34TujcWQ==",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1",
-            "prop-types": "^15.6.2"
-          }
-        }
+        "react-popper-tooltip": "^2.11.0",
+        "react-syntax-highlighter": "^12.2.1",
+        "react-textarea-autosize": "^8.1.1",
+        "ts-dedent": "^1.1.1"
       }
     },
     "@storybook/core-events": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.2.6.tgz",
-      "integrity": "sha512-W8kLJ7tc0aAxs11CPUxUOCReocKL4MYGyjTg8qwk0USLzPUb/FUQWmhcm2ilFz6Nz8dXLcKrXdRVYTmiMsgAeg==",
+      "version": "6.0.21",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/core-events/-/core-events-6.0.21.tgz",
+      "integrity": "sha512-p84fbPcsAhnqDhp+HJ4P8+vI2BqJus4IRoVAemLAwuPjyPElrV9UvOa/RHy1BN8Z6jXwFA+FFzfGl2kPJ3WYcA==",
       "dev": true,
       "requires": {
         "core-js": "^3.0.1"
       }
     },
+    "@storybook/csf": {
+      "version": "0.0.1",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/csf/-/csf-0.0.1.tgz",
+      "integrity": "sha512-USTLkZze5gkel8MYCujSRBVIrUQ3YPBrLOx7GNk/0wttvVtlzWXAq9eLbQ4p/NicGxP+3T7KPEMVV//g+yubpw==",
+      "requires": {
+        "lodash": "^4.17.15"
+      }
+    },
     "@storybook/router": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.2.6.tgz",
-      "integrity": "sha512-/FZd3fYg5s2QzOqSIP8UMOSnCIFFIlli/jKlOxvm3WpcpxgwQOY4lfHsLO+r9ThCLs2UvVg2R/HqGrOHqDFU7A==",
+      "version": "6.0.21",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/router/-/router-6.0.21.tgz",
+      "integrity": "sha512-46SsKJfcd12lRrISnfrWhicJx8EylkgGDGohfH0n5p7inkkGOkKV8QFZoYPRKZueMXmUKpzJ0Z3HmVsLTCrCDw==",
       "dev": true,
       "requires": {
-        "@reach/router": "^1.2.1",
-        "@types/reach__router": "^1.2.3",
+        "@reach/router": "^1.3.3",
+        "@types/reach__router": "^1.3.5",
         "core-js": "^3.0.1",
         "global": "^4.3.2",
-        "lodash": "^4.17.15",
         "memoizerific": "^1.11.3",
         "qs": "^6.6.0"
       }
     },
     "@storybook/theming": {
-      "version": "5.2.6",
-      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.2.6.tgz",
-      "integrity": "sha512-Xa9R/H8DDgmvxsCHloJUJ2d9ZQl80AeqHrL+c/AKNpx05s9lV74DcinusCf0kz72YGUO/Xt1bAjuOvLnAaS8Gw==",
+      "version": "6.0.21",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@storybook/theming/-/theming-6.0.21.tgz",
+      "integrity": "sha512-n97DfB9kG6WrV1xBGDyeQibTrh8pBBCp3dSL3UTGH+KX3C2+4sm6QHlTgyekbi5FrbFEbnuZOKAS3YbLVONsRQ==",
       "dev": true,
       "requires": {
-        "@emotion/core": "^10.0.14",
-        "@emotion/styled": "^10.0.14",
-        "@storybook/client-logger": "5.2.6",
-        "common-tags": "^1.8.0",
+        "@emotion/core": "^10.0.20",
+        "@emotion/is-prop-valid": "^0.8.6",
+        "@emotion/styled": "^10.0.17",
+        "@storybook/client-logger": "6.0.21",
         "core-js": "^3.0.1",
         "deep-object-diff": "^1.1.0",
-        "emotion-theming": "^10.0.14",
+        "emotion-theming": "^10.0.19",
         "global": "^4.3.2",
         "memoizerific": "^1.11.3",
-        "polished": "^3.3.1",
-        "prop-types": "^15.7.2",
-        "resolve-from": "^5.0.0"
+        "polished": "^3.4.4",
+        "resolve-from": "^5.0.0",
+        "ts-dedent": "^1.1.1"
       }
     },
     "@types/history": {
-      "version": "4.7.3",
-      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.3.tgz",
-      "integrity": "sha512-cS5owqtwzLN5kY+l+KgKdRJ/Cee8tlmQoGQuIE9tWnSmS3JMKzmxo2HIAk2wODMifGwO20d62xZQLYz+RLfXmw=="
+      "version": "4.7.7",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@types/history/-/history-4.7.7.tgz",
+      "integrity": "sha512-2xtoL22/3Mv6a70i4+4RB7VgbDDORoWwjcqeNysojZA0R7NK17RbY5Gof/2QiFfJgX+KkWghbwJ+d/2SB8Ndzg=="
     },
     "@types/is-function": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/is-function/-/is-function-1.0.0.tgz",
-      "integrity": "sha512-iTs9HReBu7evG77Q4EC8hZnqRt57irBDkK9nvmHroiOIVwYMQc4IvYvdRgwKfYepunIY7Oh/dBuuld+Gj9uo6w==",
-      "dev": true
+      "integrity": "sha512-iTs9HReBu7evG77Q4EC8hZnqRt57irBDkK9nvmHroiOIVwYMQc4IvYvdRgwKfYepunIY7Oh/dBuuld+Gj9uo6w=="
     },
     "@types/node": {
       "version": "12.12.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.7.tgz",
       "integrity": "sha512-E6Zn0rffhgd130zbCbAr/JdXfXkoOUFAKNs/rF8qnafSJ8KYaA/j3oz7dcwal+lYjLA7xvdd5J4wdYpCTlP8+w==",
       "dev": true
+    },
+    "@types/overlayscrollbars": {
+      "version": "1.12.0",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@types/overlayscrollbars/-/overlayscrollbars-1.12.0.tgz",
+      "integrity": "sha512-h/pScHNKi4mb+TrJGDon8Yb06ujFG0mSg12wIO0sWMUF3dQIe2ExRRdNRviaNt9IjxIiOfnRr7FsQAdHwK4sMg=="
+    },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
     },
     "@types/prismjs": {
       "version": "1.16.0",
@@ -746,10 +792,15 @@
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
       "integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
     },
+    "@types/qs": {
+      "version": "6.9.4",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@types/qs/-/qs-6.9.4.tgz",
+      "integrity": "sha512-+wYo+L6ZF6BMoEjtf8zB2esQsqdV6WsjRK/GP9WOgLPrq87PbNWgIxS76dS5uvl/QXtHGakZmwTznIfcPXcKlQ=="
+    },
     "@types/reach__router": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/@types/reach__router/-/reach__router-1.2.6.tgz",
-      "integrity": "sha512-Oh5DAVr/L2svBvubw6QEFpXGu295Y406BPs4i9t1n2pp7M+q3pmCmhzb9oZV5wncR41KCD3NHl1Yhi7uKnTPsA==",
+      "version": "1.3.5",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@types/reach__router/-/reach__router-1.3.5.tgz",
+      "integrity": "sha512-h0NbqXN/tJuBY/xggZSej1SKQEstbHO7J/omt1tYoFGmj3YXOodZKbbqD4mNDh7zvEGYd7YFrac1LTtAr3xsYQ==",
       "requires": {
         "@types/history": "*",
         "@types/react": "*"
@@ -764,10 +815,19 @@
         "csstype": "^2.2.0"
       }
     },
+    "@types/react-color": {
+      "version": "3.0.4",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@types/react-color/-/react-color-3.0.4.tgz",
+      "integrity": "sha512-EswbYJDF1kkrx93/YU+BbBtb46CCtDMvTiGmcOa/c5PETnwTiSWoseJ1oSWeRl/4rUXkhME9bVURvvPg0W5YQw==",
+      "requires": {
+        "@types/react": "*",
+        "@types/reactcss": "*"
+      }
+    },
     "@types/react-syntax-highlighter": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@types/react-syntax-highlighter/-/react-syntax-highlighter-10.1.0.tgz",
-      "integrity": "sha512-dF49hC4FZp1dIKyzacOrHvqMUe8U2IXyQCQXOcT1e6n64gLBp+xM6qGtPsThIT9XjiIHSg2W5Jc2V5IqekBfnA==",
+      "version": "11.0.4",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@types/react-syntax-highlighter/-/react-syntax-highlighter-11.0.4.tgz",
+      "integrity": "sha512-9GfTo3a0PHwQeTVoqs0g5bS28KkSY48pp5659wA+Dp4MqceDEa8EHBqrllJvvtyusszyJhViUEap0FDvlk/9Zg==",
       "requires": {
         "@types/react": "*"
       }
@@ -780,14 +840,18 @@
         "@types/react": "*"
       }
     },
-    "@types/react-textarea-autosize": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/@types/react-textarea-autosize/-/react-textarea-autosize-4.3.5.tgz",
-      "integrity": "sha512-PiDL83kPMTolyZAWW3lyzO6ktooTb9tFTntVy7CA83/qFLWKLJ5bLeRboy6J6j3b1e8h2Eec6gBTEOOJRjV14A==",
-      "dev": true,
+    "@types/reactcss": {
+      "version": "1.2.3",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@types/reactcss/-/reactcss-1.2.3.tgz",
+      "integrity": "sha512-d2gQQ0IL6hXLnoRfVYZukQNWHuVsE75DzFTLPUuyyEhJS8G2VvlE+qfQQ91SJjaMqlURRCNIsX7Jcsw6cEuJlA==",
       "requires": {
         "@types/react": "*"
       }
+    },
+    "@types/webpack-env": {
+      "version": "1.15.2",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/@types/webpack-env/-/webpack-env-1.15.2.tgz",
+      "integrity": "sha512-67ZgZpAlhIICIdfQrB5fnDvaKFcDxpKibxznfYRVAT4mQE41Dido/3Ty+E3xGBmTogc5+0Qb8tWhna+5B8z1iQ=="
     },
     "agent-base": {
       "version": "4.3.0",
@@ -840,14 +904,10 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
-    },
-    "asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
     },
     "axios": {
       "version": "0.16.2",
@@ -859,14 +919,14 @@
       }
     },
     "babel-plugin-emotion": {
-      "version": "10.0.23",
-      "resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.23.tgz",
-      "integrity": "sha512-1JiCyXU0t5S2xCbItejCduLGGcKmF3POT0Ujbexog2MI4IlRcIn/kWjkYwCUZlxpON0O5FC635yPl/3slr7cKQ==",
+      "version": "10.0.33",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz",
+      "integrity": "sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
-        "@emotion/hash": "0.7.3",
-        "@emotion/memoize": "0.7.3",
-        "@emotion/serialize": "^0.11.14",
+        "@emotion/hash": "0.8.0",
+        "@emotion/memoize": "0.7.4",
+        "@emotion/serialize": "^0.11.16",
         "babel-plugin-macros": "^2.0.0",
         "babel-plugin-syntax-jsx": "^6.18.0",
         "convert-source-map": "^1.5.0",
@@ -876,40 +936,19 @@
       }
     },
     "babel-plugin-macros": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.6.1.tgz",
-      "integrity": "sha512-6W2nwiXme6j1n2erPOnmRiWfObUhWH7Qw1LMi9XZy8cj+KtESu3T6asZvtk5bMQQjX8te35o7CFueiSdL/2NmQ==",
+      "version": "2.8.0",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
+      "integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
       "requires": {
-        "@babel/runtime": "^7.4.2",
-        "cosmiconfig": "^5.2.0",
-        "resolve": "^1.10.0"
+        "@babel/runtime": "^7.7.2",
+        "cosmiconfig": "^6.0.0",
+        "resolve": "^1.12.0"
       }
     },
     "babel-plugin-syntax-jsx": {
       "version": "6.18.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
       "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "2.6.10",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-          "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
-        },
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
-        }
-      }
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -1013,36 +1052,15 @@
         "y18n": "^3.2.1"
       }
     },
-    "caller-callsite": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/caller-callsite/-/caller-callsite-2.0.0.tgz",
-      "integrity": "sha1-hH4PzgoiN1CpoCfFSzNzGtMVQTQ=",
-      "requires": {
-        "callsites": "^2.0.0"
-      }
-    },
-    "caller-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-2.0.0.tgz",
-      "integrity": "sha1-Ro+DBE42mrIBD6xfBs7uFbsssfQ=",
-      "requires": {
-        "caller-callsite": "^2.0.0"
-      }
-    },
     "callsites": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-2.0.0.tgz",
-      "integrity": "sha1-BuuE8A7qQT2oav/vrL/7Ngk7PFA="
+      "version": "3.1.0",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
     "camelcase": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
       "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
-    },
-    "can-use-dom": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/can-use-dom/-/can-use-dom-0.1.0.tgz",
-      "integrity": "sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo="
     },
     "capture-stack-trace": {
       "version": "1.0.1",
@@ -1060,19 +1078,19 @@
       }
     },
     "character-entities": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-1.2.3.tgz",
-      "integrity": "sha512-yB4oYSAa9yLcGyTbB4ItFwHw43QHdH129IJ5R+WvxOkWlyFnR5FAaBNnUq4mcxsTVZGh28bHoeTHMKXH1wZf3w=="
+      "version": "1.2.4",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/character-entities/-/character-entities-1.2.4.tgz",
+      "integrity": "sha512-iBMyeEHxfVnIakwOuDXpVkc54HijNgCyQB2w0VfGQThle6NXn50zU6V/u+LDhxHcDUPojn6Kpga3PTAD8W1bQw=="
     },
     "character-entities-legacy": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-1.1.3.tgz",
-      "integrity": "sha512-YAxUpPoPwxYFsslbdKkhrGnXAtXoHNgYjlBM3WMXkWGTl5RsY3QmOyhwAgL8Nxm9l5LBThXGawxKPn68y6/fww=="
+      "version": "1.1.4",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/character-entities-legacy/-/character-entities-legacy-1.1.4.tgz",
+      "integrity": "sha512-3Xnr+7ZFS1uxeiUDvV02wQ+QDbc55o97tIV5zHScSPJpcLm/r0DFPcoY3tYRp+VZukxuMeKgXYmsXQHO05zQeA=="
     },
     "character-reference-invalid": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-1.1.3.tgz",
-      "integrity": "sha512-VOq6PRzQBam/8Jm6XBGk2fNEnHXAdGd6go0rtd4weAGECBamHDwwCQSOT12TACIYUZegUXnV6xBXqUssijtxIg=="
+      "version": "1.1.4",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/character-reference-invalid/-/character-reference-invalid-1.1.4.tgz",
+      "integrity": "sha512-mKKUkUbhPpQlCOfIuZkvSEgktjPFIsZKRRbC6KWVEMvlzblj3i3asQv5ODsrwt0N3pHAEvjP8KTQPHkp0+6jOg=="
     },
     "chardet": {
       "version": "0.7.0",
@@ -1185,19 +1203,14 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "comma-separated-tokens": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-1.0.7.tgz",
-      "integrity": "sha512-Jrx3xsP4pPv4AwJUDWY9wOXGtwPXARej6Xd99h4TUGotmf8APuquKMpK+dnD3UgyxK7OEWaisjZz+3b5jtL6xQ=="
+      "version": "1.0.8",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz",
+      "integrity": "sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw=="
     },
     "commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
-    },
-    "common-tags": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/common-tags/-/common-tags-1.8.0.tgz",
-      "integrity": "sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw=="
     },
     "concat-map": {
       "version": "0.0.1",
@@ -1230,7 +1243,7 @@
     },
     "convert-source-map": {
       "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/convert-source-map/-/convert-source-map-1.7.0.tgz",
       "integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
       "requires": {
         "safe-buffer": "~5.1.1"
@@ -1251,16 +1264,16 @@
     },
     "copy-to-clipboard": {
       "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz",
       "integrity": "sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==",
       "requires": {
         "toggle-selection": "^1.0.6"
       }
     },
     "core-js": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.4.1.tgz",
-      "integrity": "sha512-KX/dnuY/J8FtEwbnrzmAjUYgLqtk+cxM86hfG60LGiW3MmltIc2yAmDgBgEkfm0blZhUrdr1Zd84J2Y14mLxzg=="
+      "version": "3.6.5",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1268,14 +1281,15 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cosmiconfig": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
-      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
+      "version": "6.0.0",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
+      "integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
       "requires": {
-        "import-fresh": "^2.0.0",
-        "is-directory": "^0.3.1",
-        "js-yaml": "^3.13.1",
-        "parse-json": "^4.0.0"
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.1.0",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.7.2"
       }
     },
     "create-error-class": {
@@ -1287,12 +1301,12 @@
       }
     },
     "create-react-context": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.2.3.tgz",
-      "integrity": "sha512-CQBmD0+QGgTaxDL3OX1IDXYqjkp2It4RIbcb99jS6AEg27Ga+a9G3JtK6SIu0HBwPLZlmwt9F7UwWA4Bn92Rag==",
+      "version": "0.3.0",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/create-react-context/-/create-react-context-0.3.0.tgz",
+      "integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
       "requires": {
-        "fbjs": "^0.8.0",
-        "gud": "^1.0.0"
+        "gud": "^1.0.0",
+        "warning": "^4.0.3"
       }
     },
     "cross-spawn": {
@@ -1353,6 +1367,19 @@
         "ms": "^2.1.1"
       }
     },
+    "deep-equal": {
+      "version": "1.1.1",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/deep-equal/-/deep-equal-1.1.1.tgz",
+      "integrity": "sha512-yd9c5AdiqVcR+JjcwUQb9DkhJc8ngNr0MahEBGvDiJw8puWab2yZlh+nkasOnZP+EGTAP6rRp2JzJhJZzvNF8g==",
+      "requires": {
+        "is-arguments": "^1.0.4",
+        "is-date-object": "^1.0.1",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object-keys": "^1.1.1",
+        "regexp.prototype.flags": "^1.2.0"
+      }
+    },
     "deep-extend": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -1360,8 +1387,16 @@
     },
     "deep-object-diff": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/deep-object-diff/-/deep-object-diff-1.1.0.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/deep-object-diff/-/deep-object-diff-1.1.0.tgz",
       "integrity": "sha512-b+QLs5vHgS+IoSNcUE4n9HP2NwcHj7aqnJWsjPtuG75Rh5TOaGt0OjAYInh77d5T16V5cRDC+Pw/6ZZZiETBGw=="
+    },
+    "define-properties": {
+      "version": "1.1.3",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/define-properties/-/define-properties-1.1.3.tgz",
+      "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
+      "requires": {
+        "object-keys": "^1.0.12"
+      }
     },
     "delegate": {
       "version": "3.2.0",
@@ -1377,16 +1412,16 @@
     },
     "dom-helpers": {
       "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.4.0.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/dom-helpers/-/dom-helpers-3.4.0.tgz",
       "integrity": "sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==",
       "requires": {
         "@babel/runtime": "^7.1.2"
       }
     },
     "dom-walk": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
+      "version": "0.1.2",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
     },
     "dot-prop": {
       "version": "4.2.0",
@@ -1422,12 +1457,12 @@
       }
     },
     "emotion-theming": {
-      "version": "10.0.19",
-      "resolved": "https://registry.npmjs.org/emotion-theming/-/emotion-theming-10.0.19.tgz",
-      "integrity": "sha512-dQRBPLAAQ6eA8JKhkLCIWC8fdjPbiNC1zNTdFF292h9amhZXofcNGUP7axHoHX4XesqQESYwZrXp53OPInMrKw==",
+      "version": "10.0.27",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/emotion-theming/-/emotion-theming-10.0.27.tgz",
+      "integrity": "sha512-MlF1yu/gYh8u+sLUqA0YuA9JX0P4Hb69WlKc/9OLo+WCXuX6sy/KoIa+qJimgmr2dWqnypYKYPX37esjDBbhdw==",
       "requires": {
         "@babel/runtime": "^7.5.5",
-        "@emotion/weak-memoize": "0.2.4",
+        "@emotion/weak-memoize": "0.2.5",
         "hoist-non-react-statics": "^3.3.0"
       }
     },
@@ -1462,10 +1497,38 @@
     },
     "error-ex": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/error-ex/-/error-ex-1.3.2.tgz",
       "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "requires": {
         "is-arrayish": "^0.2.1"
+      }
+    },
+    "es-abstract": {
+      "version": "1.17.6",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/es-abstract/-/es-abstract-1.17.6.tgz",
+      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
+      "requires": {
+        "es-to-primitive": "^1.2.1",
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1",
+        "is-callable": "^1.2.0",
+        "is-regex": "^1.1.0",
+        "object-inspect": "^1.7.0",
+        "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
+      }
+    },
+    "es-to-primitive": {
+      "version": "1.2.1",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+      "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+      "requires": {
+        "is-callable": "^1.1.4",
+        "is-date-object": "^1.0.1",
+        "is-symbol": "^1.0.2"
       }
     },
     "es6-promise": {
@@ -1483,7 +1546,7 @@
     },
     "escape-html": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
@@ -1494,17 +1557,13 @@
     "esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
     },
     "esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
-    },
-    "eventemitter3": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.0.tgz",
-      "integrity": "sha512-qerSRB0p+UDEssxTtm6EDKcE7W4OaoisfIMl4CngyEhjpYglocpNg6UEqCvemdGhosAsg4sO2dXJOdyBifPGCg=="
     },
     "execa": {
       "version": "0.7.0",
@@ -1547,37 +1606,16 @@
       }
     },
     "fast-deep-equal": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk="
+      "version": "3.1.3",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "fault": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/fault/-/fault-1.0.3.tgz",
-      "integrity": "sha512-sfFuP4X0hzrbGKjAUNXYvNqsZ5F6ohx/dZ9I0KQud/aiZNwg263r5L9yGB0clvXHCkzXh5W3t7RSHchggYIFmA==",
+      "version": "1.0.4",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/fault/-/fault-1.0.4.tgz",
+      "integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
       "requires": {
-        "format": "^0.2.2"
-      }
-    },
-    "fbjs": {
-      "version": "0.8.17",
-      "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
-      "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
-      "requires": {
-        "core-js": "^1.0.0",
-        "isomorphic-fetch": "^2.1.1",
-        "loose-envify": "^1.0.0",
-        "object-assign": "^4.1.0",
-        "promise": "^7.1.1",
-        "setimmediate": "^1.0.5",
-        "ua-parser-js": "^0.7.18"
-      },
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.7",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
-          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
-        }
+        "format": "^0.2.0"
       }
     },
     "figures": {
@@ -1617,8 +1655,17 @@
     },
     "find-root": {
       "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/find-root/-/find-root-1.1.0.tgz",
       "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+    },
+    "find-up": {
+      "version": "4.1.0",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "requires": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      }
     },
     "flush-write-stream": {
       "version": "1.1.1",
@@ -1628,11 +1675,6 @@
         "inherits": "^2.0.3",
         "readable-stream": "^2.3.6"
       }
-    },
-    "focus-lock": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/focus-lock/-/focus-lock-0.6.6.tgz",
-      "integrity": "sha512-Dx69IXGCq1qsUExWuG+5wkiMqVM/zGx/reXSJSLogECwp3x6KeNQZ+NAetgxEFpnC41rD8U3+jRCW68+LNzdtw=="
     },
     "follow-redirects": {
       "version": "1.9.0",
@@ -1644,7 +1686,7 @@
     },
     "format": {
       "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/format/-/format-0.2.2.tgz",
       "integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
     },
     "from2": {
@@ -1694,7 +1736,7 @@
     },
     "function-bind": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "genfun": {
@@ -1774,7 +1816,7 @@
     },
     "global": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/global/-/global-4.4.0.tgz",
       "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
       "requires": {
         "min-document": "^2.19.0",
@@ -1843,12 +1885,12 @@
     },
     "gud": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/gud/-/gud-1.0.0.tgz",
       "integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
     },
     "has": {
       "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "requires": {
         "function-bind": "^1.1.1"
@@ -1860,19 +1902,19 @@
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+      "version": "1.0.1",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/has-symbols/-/has-symbols-1.0.1.tgz",
+      "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg=="
     },
     "hast-util-parse-selector": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/hast-util-parse-selector/-/hast-util-parse-selector-2.2.3.tgz",
-      "integrity": "sha512-nxbeqjQNxsvo/uYYAw9kij6td05YVUlf1qti09rVfbWSLT5H6wo3c+USIwX6nzXWk5kFZzXnEqO82856r0aM2Q=="
+      "version": "2.2.4",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/hast-util-parse-selector/-/hast-util-parse-selector-2.2.4.tgz",
+      "integrity": "sha512-gW3sxfynIvZApL4L07wryYF4+C9VvH3AUi7LAnVXV4MneGEgwOByXvFo18BgmTWnm7oHAe874jKbIB1YhHSIzA=="
     },
     "hastscript": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/hastscript/-/hastscript-5.1.1.tgz",
-      "integrity": "sha512-xHo1Hkcqd0LlWNuDL3/BxwhgAGp3d7uEvCMgCTrBY+zsOooPPH+8KAvW8PCgl+GB8H3H44nfSaF0A4BQ+4xlYg==",
+      "version": "5.1.2",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/hastscript/-/hastscript-5.1.2.tgz",
+      "integrity": "sha512-WlztFuK+Lrvi3EggsqOkQ52rKbxkXL3RwB6t5lwoa8QLMemoWfBuL43eDrwOamJyR7uKQKdmKYaBH1NZBiIRrQ==",
       "requires": {
         "comma-separated-tokens": "^1.0.0",
         "hast-util-parse-selector": "^2.0.0",
@@ -1881,14 +1923,14 @@
       }
     },
     "highlight.js": {
-      "version": "9.12.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
-      "integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
+      "version": "9.15.10",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/highlight.js/-/highlight.js-9.15.10.tgz",
+      "integrity": "sha512-RoV7OkQm0T3os3Dd2VHLNMoaoDVx77Wygln3n9l5YV172XonWG6rgQD3XnF/BuFFZw9A0TJgmMSO8FEWQgvcXw=="
     },
     "hoist-non-react-statics": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.0.tgz",
-      "integrity": "sha512-0XsbTXxgiaCDYDIWFcwkmerZPSwywfUqYmwT4jzewKTQSWoE6FCMoUVOeBJWK3E/CrWbxRG3m5GzY4lnIwGRBA==",
+      "version": "3.3.2",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+      "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
       "requires": {
         "react-is": "^16.7.0"
       }
@@ -1976,18 +2018,18 @@
       "integrity": "sha512-47xSUiQioGaB96nqtp5/q55m0aBQSQdyIloMOc/x+QVTDZLNmXE892IIDrJ0hM1A5vcNUDD5tDffkSP5lCaIIA=="
     },
     "import-fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
-      "integrity": "sha1-2BNVwVYS04bGH53dOSLUMEgipUY=",
+      "version": "3.2.1",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/import-fresh/-/import-fresh-3.2.1.tgz",
+      "integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
       "requires": {
-        "caller-path": "^2.0.0",
-        "resolve-from": "^3.0.0"
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
       },
       "dependencies": {
         "resolve-from": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-          "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+          "version": "4.0.0",
+          "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/resolve-from/-/resolve-from-4.0.0.tgz",
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
         }
       }
     },
@@ -2042,7 +2084,7 @@
     },
     "invariant": {
       "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/invariant/-/invariant-2.2.4.tgz",
       "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
       "requires": {
         "loose-envify": "^1.0.0"
@@ -2054,28 +2096,38 @@
       "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "is-alphabetical": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-1.0.3.tgz",
-      "integrity": "sha512-eEMa6MKpHFzw38eKm56iNNi6GJ7lf6aLLio7Kr23sJPAECscgRtZvOBYybejWDQ2bM949Y++61PY+udzj5QMLA=="
+      "version": "1.0.4",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/is-alphabetical/-/is-alphabetical-1.0.4.tgz",
+      "integrity": "sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg=="
     },
     "is-alphanumerical": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-1.0.3.tgz",
-      "integrity": "sha512-A1IGAPO5AW9vSh7omxIlOGwIqEvpW/TA+DksVOPM5ODuxKlZS09+TEM1E3275lJqO2oJ38vDpeAL3DCIiHE6eA==",
+      "version": "1.0.4",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/is-alphanumerical/-/is-alphanumerical-1.0.4.tgz",
+      "integrity": "sha512-UzoZUr+XfVz3t3v4KyGEniVL9BDRoQtY7tOyrRybkVNjDFWyo1yhXNGrrBTQxp3ib9BLAWs7k2YKBQsFRkZG9A==",
       "requires": {
         "is-alphabetical": "^1.0.0",
         "is-decimal": "^1.0.0"
       }
     },
+    "is-arguments": {
+      "version": "1.0.4",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/is-arguments/-/is-arguments-1.0.4.tgz",
+      "integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA=="
+    },
     "is-arrayish": {
       "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/is-arrayish/-/is-arrayish-0.2.1.tgz",
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
+    "is-callable": {
+      "version": "1.2.0",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/is-callable/-/is-callable-1.2.0.tgz",
+      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
     },
     "is-ci": {
       "version": "1.2.1",
@@ -2085,15 +2137,15 @@
         "ci-info": "^1.5.0"
       }
     },
-    "is-decimal": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-1.0.3.tgz",
-      "integrity": "sha512-bvLSwoDg2q6Gf+E2LEPiklHZxxiSi3XAh4Mav65mKqTfCO1HM3uBs24TjEH8iJX3bbDdLXKJXBTmGzuTUuAEjQ=="
+    "is-date-object": {
+      "version": "1.0.2",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/is-date-object/-/is-date-object-1.0.2.tgz",
+      "integrity": "sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g=="
     },
-    "is-directory": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
-      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE="
+    "is-decimal": {
+      "version": "1.0.4",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/is-decimal/-/is-decimal-1.0.4.tgz",
+      "integrity": "sha512-RGdriMmQQvZ2aqaQq3awNA6dCGtKpiDFcOzrTWrDAT2MiWrKQVPmxLGHl7Y2nNu6led0kEyoX0enY0qXYsv9zw=="
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -2106,14 +2158,14 @@
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-function": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
-      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
+      "version": "1.0.2",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/is-function/-/is-function-1.0.2.tgz",
+      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
     },
     "is-hexadecimal": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-1.0.3.tgz",
-      "integrity": "sha512-zxQ9//Q3D/34poZf8fiy3m3XVpbQc7ren15iKqrTtLPwkPD/t3Scy9Imp63FujULGxuK0ZlCwoo5xNpktFgbOA=="
+      "version": "1.0.4",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/is-hexadecimal/-/is-hexadecimal-1.0.4.tgz",
+      "integrity": "sha512-gyPJuv83bHMpocVYoqof5VDiZveEoGoFL8m3BXNb2VW8Xs+rz9kqO8LOQ5DH6EsuvilT1ApazU0pyl+ytbPtlw=="
     },
     "is-installed-globally": {
       "version": "0.1.0",
@@ -2142,14 +2194,6 @@
         "path-is-inside": "^1.0.1"
       }
     },
-    "is-plain-object": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
-      "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
-      "requires": {
-        "isobject": "^4.0.0"
-      }
-    },
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
@@ -2161,11 +2205,11 @@
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
     },
     "is-regex": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
-      "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "version": "1.1.1",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/is-regex/-/is-regex-1.1.1.tgz",
+      "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
       "requires": {
-        "has": "^1.0.1"
+        "has-symbols": "^1.0.1"
       }
     },
     "is-retry-allowed": {
@@ -2179,11 +2223,11 @@
       "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-symbol": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "version": "1.0.3",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
       "requires": {
-        "has-symbols": "^1.0.0"
+        "has-symbols": "^1.0.1"
       }
     },
     "is-windows": {
@@ -2208,17 +2252,8 @@
     },
     "isobject": {
       "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/isobject/-/isobject-4.0.0.tgz",
       "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA=="
-    },
-    "isomorphic-fetch": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
-      "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "requires": {
-        "node-fetch": "^1.0.1",
-        "whatwg-fetch": ">=0.10.0"
-      }
     },
     "istextorbinary": {
       "version": "2.6.0",
@@ -2239,6 +2274,7 @@
       "version": "3.13.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
       "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+      "dev": true,
       "requires": {
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
@@ -2248,6 +2284,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+    },
+    "json-parse-even-better-errors": {
+      "version": "2.3.0",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.0.tgz",
+      "integrity": "sha512-o3aP+RsWDJZayj1SbHNQAI8x0v3T3SKiGoZlNYfbUP1S3omJQ6i9CnqADqkSPaOAxwua4/1YWx5CM7oiChJt2Q=="
     },
     "jsonfile": {
       "version": "3.0.1",
@@ -2270,25 +2311,23 @@
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
       "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4="
     },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
+    },
+    "locate-path": {
+      "version": "5.0.0",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "requires": {
+        "p-locate": "^4.1.0"
+      }
+    },
     "lodash": {
       "version": "4.17.15",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
       "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
-    },
-    "lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168="
-    },
-    "lodash.memoize": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-      "integrity": "sha1-vMbEmkKihA7Zl/Mj6tpezRguC/4="
-    },
-    "lodash.throttle": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
     },
     "log-symbols": {
       "version": "2.2.0",
@@ -2312,12 +2351,12 @@
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
     },
     "lowlight": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.9.2.tgz",
-      "integrity": "sha512-Ek18ElVCf/wF/jEm1b92gTnigh94CtBNWiZ2ad+vTgW7cTmQxUY3I98BjHK68gZAJEWmybGBZgx9qv3QxLQB/Q==",
+      "version": "1.12.1",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/lowlight/-/lowlight-1.12.1.tgz",
+      "integrity": "sha512-OqaVxMGIESnawn+TU/QMV5BJLbUghUfjDWPAtFqDYDmDtr4FnB+op8xM+pR7nKlauHNUHXGt0VgWatFB8voS5w==",
       "requires": {
         "fault": "^1.0.2",
-        "highlight.js": "~9.12.0"
+        "highlight.js": "~9.15.0"
       }
     },
     "lru-cache": {
@@ -2425,13 +2464,13 @@
     },
     "map-or-similar": {
       "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/map-or-similar/-/map-or-similar-1.5.0.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/map-or-similar/-/map-or-similar-1.5.0.tgz",
       "integrity": "sha1-beJlMXSt+12e3DPGnT6Sobdvrwg="
     },
     "markdown-to-jsx": {
-      "version": "6.10.3",
-      "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.10.3.tgz",
-      "integrity": "sha512-PSoUyLnW/xoW6RsxZrquSSz5eGEOTwa15H5eqp3enmrp8esmgDJmhzd6zmQ9tgAA9TxJzx1Hmf3incYU/IamoQ==",
+      "version": "6.11.4",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/markdown-to-jsx/-/markdown-to-jsx-6.11.4.tgz",
+      "integrity": "sha512-3lRCD5Sh+tfA52iGgfs/XZiw33f7fFX9Bn55aNnVNUd2GzLDkOWyKYYD8Yju2B1Vn+feiEdgJs8T6Tg0xNokPw==",
       "requires": {
         "prop-types": "^15.6.2",
         "unquote": "^1.1.0"
@@ -2439,17 +2478,17 @@
     },
     "material-colors": {
       "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/material-colors/-/material-colors-1.2.6.tgz",
       "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg=="
     },
     "memoize-one": {
       "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/memoize-one/-/memoize-one-5.1.1.tgz",
       "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA=="
     },
     "memoizerific": {
       "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/memoizerific/-/memoizerific-1.11.3.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/memoizerific/-/memoizerific-1.11.3.tgz",
       "integrity": "sha1-fIekZGREwy11Q4VwkF8tvRsagFo=",
       "requires": {
         "map-or-similar": "^1.5.0"
@@ -2467,7 +2506,7 @@
     },
     "min-document": {
       "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
       "requires": {
         "dom-walk": "^0.1.0"
@@ -2538,15 +2577,6 @@
       "version": "2.1.7",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.7.tgz",
       "integrity": "sha512-fmS3qwDldm4bE01HCIRqNk+f255CNjnAoeV3Zzzv0KemObHKqYgirVaZA9DtKcjogicWjYcHkJs4D5A8CjnuVQ=="
-    },
-    "node-fetch": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
-      "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "requires": {
-        "encoding": "^0.1.11",
-        "is-stream": "^1.0.1"
-      }
     },
     "node-fetch-npm": {
       "version": "2.0.2",
@@ -2623,6 +2653,36 @@
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
+    "object-inspect": {
+      "version": "1.8.0",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/object-inspect/-/object-inspect-1.8.0.tgz",
+      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
+    },
+    "object-is": {
+      "version": "1.1.2",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/object-is/-/object-is-1.1.2.tgz",
+      "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "object-keys": {
+      "version": "1.1.1",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/object-keys/-/object-keys-1.1.1.tgz",
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
+    },
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "requires": {
+        "define-properties": "^1.1.2",
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -2677,10 +2737,36 @@
         "os-tmpdir": "^1.0.0"
       }
     },
+    "overlayscrollbars": {
+      "version": "1.13.0",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/overlayscrollbars/-/overlayscrollbars-1.13.0.tgz",
+      "integrity": "sha512-p8oHrMeRAKxXDMPI/EBNITj/zTVHKNnAnM59Im+xnoZUlV07FyTg46wom2286jJlXGGfcPFG/ba5NUiCwWNd4w=="
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+    },
+    "p-limit": {
+      "version": "2.3.0",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "4.1.0",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "requires": {
+        "p-limit": "^2.2.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
     "package-json": {
       "version": "4.0.1",
@@ -2745,9 +2831,17 @@
         "readable-stream": "^2.1.5"
       }
     },
+    "parent-module": {
+      "version": "1.0.1",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
     "parse-entities": {
       "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-1.2.2.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/parse-entities/-/parse-entities-1.2.2.tgz",
       "integrity": "sha512-NzfpbxW/NPrzZ/yYSoQxyqUZMZXIdCfE0OIN4ESsnptHJECoUk3FZktxNuzQf4tjt5UEopnxpYJbvYuxIFDdsg==",
       "requires": {
         "character-entities": "^1.0.0",
@@ -2770,18 +2864,25 @@
       }
     },
     "parse-json": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
-      "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+      "version": "5.1.0",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/parse-json/-/parse-json-5.1.0.tgz",
+      "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
       "requires": {
+        "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
-        "json-parse-better-errors": "^1.0.1"
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
       }
     },
     "parse-passwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="
     },
     "path-is-absolute": {
       "version": "1.0.1",
@@ -2803,23 +2904,28 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
       "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+    },
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
     },
     "polished": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/polished/-/polished-3.4.2.tgz",
-      "integrity": "sha512-9Rch6iMZckABr6EFCLPZsxodeBpXMo9H4fRlfR/9VjMEyy5xpo1/WgXlJGgSjPyVhEZNycbW7UmYMNyWS5MI0g==",
+      "version": "3.6.6",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/polished/-/polished-3.6.6.tgz",
+      "integrity": "sha512-yiB2ims2DZPem0kCD6V0wnhcVGFEhNh0Iw0axNpKU+oSAgFt6yx6HxIT23Qg0WWvgS379cS35zT4AOyZZRzpQQ==",
       "requires": {
-        "@babel/runtime": "^7.6.3"
+        "@babel/runtime": "^7.9.2"
       }
     },
     "popper.js": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.0.tgz",
-      "integrity": "sha512-+G+EkOPoE5S/zChTpmBSSDYmhXJ5PsW8eMhH8cP/CQHMFPBG/kC9Y5IIw6qNYgdJ+/COf0ddY2li28iHaZRSjw=="
+      "version": "1.16.1",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/popper.js/-/popper.js-1.16.1.tgz",
+      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
     },
     "prepend-http": {
       "version": "1.0.4",
@@ -2836,21 +2942,13 @@
     },
     "process": {
       "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/process/-/process-0.11.10.tgz",
       "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
     },
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-    },
-    "promise": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/promise/-/promise-7.3.1.tgz",
-      "integrity": "sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==",
-      "requires": {
-        "asap": "~2.0.3"
-      }
     },
     "promise-inflight": {
       "version": "1.0.1",
@@ -2877,11 +2975,11 @@
       }
     },
     "property-information": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.3.0.tgz",
-      "integrity": "sha512-IslotQn1hBCZDY7SaJ3zmCjVea219VTwmOk6Pu3z9haU9m4+T8GwaDubur+6NMHEU+Fjs/6/p66z6QULPkcL1w==",
+      "version": "5.5.0",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/property-information/-/property-information-5.5.0.tgz",
+      "integrity": "sha512-RgEbCx2HLa1chNgvChcx+rrCWD0ctBmGSE0M7lVm1yyv4UbvbrWoXp/BkVLZefzjrRBGW8/Js6uh/BnlHXFyjA==",
       "requires": {
-        "xtend": "^4.0.1"
+        "xtend": "^4.0.0"
       }
     },
     "protoduck": {
@@ -2928,9 +3026,9 @@
       }
     },
     "qs": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.1.tgz",
-      "integrity": "sha512-Cxm7/SS/y/Z3MHWSxXb8lIFqgqBowP5JMlTUFyJN88y0SGQhVmZnqFK/PeuMX9LzUyWsqqhNxIyg0jlzq946yA=="
+      "version": "6.9.4",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/qs/-/qs-6.9.4.tgz",
+      "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
     },
     "rc": {
       "version": "1.2.8",
@@ -2954,25 +3052,16 @@
       "version": "16.13.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.13.0.tgz",
       "integrity": "sha512-TSavZz2iSLkq5/oiE7gnFzmURKZMltmi193rm5HEoUDAXpzT9Kzw6oNZnGoai/4+fUnm7FqS5dwgUL34TujcWQ==",
-      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2"
       }
     },
-    "react-clientside-effect": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/react-clientside-effect/-/react-clientside-effect-1.2.2.tgz",
-      "integrity": "sha512-nRmoyxeok5PBO6ytPvSjKp9xwXg9xagoTK1mMjwnQxqM9Hd7MNPl+LS1bOSOe+CV2+4fnEquc7H/S8QD3q697A==",
-      "requires": {
-        "@babel/runtime": "^7.0.0"
-      }
-    },
     "react-color": {
-      "version": "2.18.0",
-      "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.18.0.tgz",
-      "integrity": "sha512-FyVeU1kQiSokWc8NPz22azl1ezLpJdUyTbWL0LPUpcuuYDrZ/Y1veOk9rRK5B3pMlyDGvTk4f4KJhlkIQNRjEA==",
+      "version": "2.18.1",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/react-color/-/react-color-2.18.1.tgz",
+      "integrity": "sha512-X5XpyJS6ncplZs74ak0JJoqPi+33Nzpv5RYWWxn17bslih+X7OlgmfpmGC1fNvdkK7/SGWYf1JJdn7D2n5gSuQ==",
       "requires": {
         "@icons/material": "^0.2.4",
         "lodash": "^4.17.11",
@@ -2983,47 +3072,19 @@
       }
     },
     "react-dom": {
-      "version": "16.11.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.11.0.tgz",
-      "integrity": "sha512-nrRyIUE1e7j8PaXSPtyRKtz+2y9ubW/ghNgqKFHHAHaeP0fpF5uXR+sq8IMRHC+ZUxw7W9NyCDTBtwWxvkb0iA==",
+      "version": "16.13.1",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/react-dom/-/react-dom-16.13.1.tgz",
+      "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.17.0"
-      }
-    },
-    "react-fast-compare": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-2.0.4.tgz",
-      "integrity": "sha512-suNP+J1VU1MWFKcyt7RtjiSWUjvidmQSlqu+eHslq+342xCbGTYmC0mEhPCOHxlW0CywylOC1u2DFAT+bv4dBw=="
-    },
-    "react-focus-lock": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/react-focus-lock/-/react-focus-lock-1.19.1.tgz",
-      "integrity": "sha512-TPpfiack1/nF4uttySfpxPk4rGZTLXlaZl7ncZg/ELAk24Iq2B1UUaUioID8H8dneUXqznT83JTNDHDj+kwryw==",
-      "requires": {
-        "@babel/runtime": "^7.0.0",
-        "focus-lock": "^0.6.3",
-        "prop-types": "^15.6.2",
-        "react-clientside-effect": "^1.2.0"
-      }
-    },
-    "react-helmet-async": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-1.0.4.tgz",
-      "integrity": "sha512-KTGHE9sz8N7+fCkZ2a3vzXH9eIkiTNhL2NhKR7XzzQl3WsGlCHh76arauJUIiGdfhjeMp7DY7PkASAmYFXeJYg==",
-      "requires": {
-        "@babel/runtime": "^7.3.4",
-        "invariant": "^2.2.4",
-        "prop-types": "^15.7.2",
-        "react-fast-compare": "^2.0.4",
-        "shallowequal": "^1.1.0"
+        "scheduler": "^0.19.1"
       }
     },
     "react-input-autosize": {
       "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.2.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/react-input-autosize/-/react-input-autosize-2.2.2.tgz",
       "integrity": "sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==",
       "requires": {
         "prop-types": "^15.5.8"
@@ -3036,53 +3097,35 @@
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
     "react-popper": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-1.3.6.tgz",
-      "integrity": "sha512-kLTfa9z8n+0jJvRVal9+vIuirg41rObg4Bbrvv/ZfsGPQDN9reyVVSxqnHF1ZNgXgV7x11PeUfd5ItF8DZnqhg==",
+      "version": "1.3.7",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/react-popper/-/react-popper-1.3.7.tgz",
+      "integrity": "sha512-nmqYTx7QVjCm3WUZLeuOomna138R1luC4EqkW3hxJUrAe+3eNz3oFCLYdnPwILfn0mX1Ew2c3wctrjlUMYYUww==",
       "requires": {
         "@babel/runtime": "^7.1.2",
         "create-react-context": "^0.3.0",
+        "deep-equal": "^1.1.1",
         "popper.js": "^1.14.4",
         "prop-types": "^15.6.1",
         "typed-styles": "^0.0.7",
         "warning": "^4.0.2"
-      },
-      "dependencies": {
-        "create-react-context": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz",
-          "integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
-          "requires": {
-            "gud": "^1.0.0",
-            "warning": "^4.0.3"
-          }
-        },
-        "warning": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-          "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-          "requires": {
-            "loose-envify": "^1.0.0"
-          }
-        }
       }
     },
     "react-popper-tooltip": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/react-popper-tooltip/-/react-popper-tooltip-2.10.0.tgz",
-      "integrity": "sha512-iMNWaY41G7kcx2/kcV+37GLe4C93yI9CPZ9DH+V9tOtJIJwEzm/w9+mlr6G1QLzxefDxjliqymMXk9X73pyuWA==",
+      "version": "2.11.1",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/react-popper-tooltip/-/react-popper-tooltip-2.11.1.tgz",
+      "integrity": "sha512-04A2f24GhyyMicKvg/koIOQ5BzlrRbKiAgP6L+Pdj1MVX3yJ1NeZ8+EidndQsbejFT55oW1b++wg2Z8KlAyhfQ==",
       "requires": {
-        "@babel/runtime": "^7.6.3",
-        "react-popper": "^1.3.4"
+        "@babel/runtime": "^7.9.2",
+        "react-popper": "^1.3.7"
       }
     },
     "react-select": {
       "version": "3.0.8",
-      "resolved": "https://registry.npmjs.org/react-select/-/react-select-3.0.8.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/react-select/-/react-select-3.0.8.tgz",
       "integrity": "sha512-v9LpOhckLlRmXN5A6/mGGEft4FMrfaBFTGAnuPHcUgVId7Je42kTq9y0Z+Ye5z8/j0XDT3zUqza8gaRaI1PZIg==",
       "requires": {
         "@babel/runtime": "^7.4.4",
@@ -3096,13 +3139,13 @@
       }
     },
     "react-syntax-highlighter": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/react-syntax-highlighter/-/react-syntax-highlighter-8.1.0.tgz",
-      "integrity": "sha512-G2bkZxmF3VOa4atEdXIDSfwwCqjw6ZQX5znfTaHcErA1WqHIS0o6DaSCDKFPVaOMXQEB9Hf1UySYQvuJmV8CXg==",
+      "version": "12.2.1",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/react-syntax-highlighter/-/react-syntax-highlighter-12.2.1.tgz",
+      "integrity": "sha512-CTsp0ZWijwKRYFg9xhkWD4DSpQqE4vb2NKVMdPAkomnILSmsNBHE0n5GuI5zB+PU3ySVvXvdt9jo+ViD9XibCA==",
       "requires": {
-        "babel-runtime": "^6.18.0",
-        "highlight.js": "~9.12.0",
-        "lowlight": "~1.9.1",
+        "@babel/runtime": "^7.3.1",
+        "highlight.js": "~9.15.1",
+        "lowlight": "1.12.1",
         "prismjs": "^1.8.4",
         "refractor": "^2.4.1"
       }
@@ -3117,17 +3160,18 @@
       }
     },
     "react-textarea-autosize": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/react-textarea-autosize/-/react-textarea-autosize-7.1.2.tgz",
-      "integrity": "sha512-uH3ORCsCa3C6LHxExExhF4jHoXYCQwE5oECmrRsunlspaDAbS4mGKNlWZqjLfInWtFQcf0o1n1jC/NGXFdUBCg==",
+      "version": "8.2.0",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/react-textarea-autosize/-/react-textarea-autosize-8.2.0.tgz",
+      "integrity": "sha512-grajUlVbkx6VdtSxCgzloUIphIZF5bKr21OYMceWPKkniy7H0mRAT/AXPrRtObAe+zUePnNlBwUc4ivVjUGIjw==",
       "requires": {
-        "@babel/runtime": "^7.1.2",
-        "prop-types": "^15.6.0"
+        "@babel/runtime": "^7.10.2",
+        "use-composed-ref": "^1.0.0",
+        "use-latest": "^1.0.0"
       }
     },
     "react-transition-group": {
       "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.9.0.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/react-transition-group/-/react-transition-group-2.9.0.tgz",
       "integrity": "sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==",
       "requires": {
         "dom-helpers": "^3.4.0",
@@ -3138,7 +3182,7 @@
     },
     "reactcss": {
       "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/reactcss/-/reactcss-1.2.3.tgz",
       "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
       "requires": {
         "lodash": "^4.0.1"
@@ -3159,9 +3203,9 @@
       }
     },
     "refractor": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/refractor/-/refractor-2.10.0.tgz",
-      "integrity": "sha512-maW2ClIkm9IYruuFYGTqKzj+m31heq92wlheW4h7bOstP+gf8bocmMec+j7ljLcaB1CAID85LMB3moye31jH1g==",
+      "version": "2.10.1",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/refractor/-/refractor-2.10.1.tgz",
+      "integrity": "sha512-Xh9o7hQiQlDbxo5/XkOX6H+x/q8rmlmZKr97Ie1Q8ZM32IRRd3B/UxuA/yXDW79DBSXGWxm2yRTbcTVmAciJRw==",
       "requires": {
         "hastscript": "^5.0.0",
         "parse-entities": "^1.1.2",
@@ -3169,9 +3213,18 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz",
-      "integrity": "sha512-naKIZz2GQ8JWh///G7L3X6LaQUAMp2lvb1rvwwsURe/VXwD6VMfr+/1NuNw3ag8v2kY1aQ/go5SNn79O9JU7yw=="
+      "version": "0.13.5",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
+      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+    },
+    "regexp.prototype.flags": {
+      "version": "1.3.0",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/regexp.prototype.flags/-/regexp.prototype.flags-1.3.0.tgz",
+      "integrity": "sha512-2+Q0C5g951OlYlJz6yu5/M33IcsESLlLfsyIaLJaG4FA2r4yP8MvVMJUUP/fVBkSpbbbZlS5gynbEWLipiiXiQ==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
+      }
     },
     "registry-auth-token": {
       "version": "3.4.0",
@@ -3198,11 +3251,6 @@
         "parse-git-config": "^1.1.1"
       }
     },
-    "resize-observer-polyfill": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
-      "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg=="
-    },
     "resolve": {
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
@@ -3222,7 +3270,7 @@
     },
     "resolve-from": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/resolve-from/-/resolve-from-5.0.0.tgz",
       "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
     },
     "restore-cursor": {
@@ -3282,9 +3330,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "scheduler": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.17.0.tgz",
-      "integrity": "sha512-7rro8Io3tnCPuY4la/NuI5F2yfESpnfZyT6TtkXnSWVkcu0BCDJ+8gk5ozUaFaxpIyNuWAPXrH0yFcSi28fnDA==",
+      "version": "0.19.1",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/scheduler/-/scheduler-0.19.1.tgz",
+      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -3316,21 +3364,6 @@
         }
       }
     },
-    "setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU="
-    },
-    "shallow-equal": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/shallow-equal/-/shallow-equal-1.2.0.tgz",
-      "integrity": "sha512-Z21pVxR4cXsfwpMKMhCEIO1PCi5sp7KEp+CmOpBQ+E8GpHwKOw2sEzk7sgblM3d/j4z4gakoWEoPcjK0VJQogA=="
-    },
-    "shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ=="
-    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -3357,28 +3390,6 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
-    "simplebar": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/simplebar/-/simplebar-4.2.3.tgz",
-      "integrity": "sha512-9no0pK7/1y+8/oTF3sy/+kx0PjQ3uk4cYwld5F1CJGk2gx+prRyUq8GRfvcVLq5niYWSozZdX73a2wIr1o9l/g==",
-      "requires": {
-        "can-use-dom": "^0.1.0",
-        "core-js": "^3.0.1",
-        "lodash.debounce": "^4.0.8",
-        "lodash.memoize": "^4.1.2",
-        "lodash.throttle": "^4.1.1",
-        "resize-observer-polyfill": "^1.5.1"
-      }
-    },
-    "simplebar-react": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/simplebar-react/-/simplebar-react-1.2.3.tgz",
-      "integrity": "sha512-1EOWJzFC7eqHUp1igD1/tb8GBv5aPQA5ZMvpeDnVkpNJ3jAuvmrL2kir3HuijlxhG7njvw9ssxjjBa89E5DrJg==",
-      "requires": {
-        "prop-types": "^15.6.1",
-        "simplebar": "^4.2.3"
-      }
-    },
     "smart-buffer": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
@@ -3404,13 +3415,13 @@
     },
     "source-map": {
       "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "space-separated-tokens": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-1.1.4.tgz",
-      "integrity": "sha512-UyhMSmeIqZrQn2UdjYpxEkwY9JUrn8pP+7L4f91zRzOQuI8MF1FGLfYU9DKCYeLdo7LXMxwrX5zKFy7eeeVHuA=="
+      "version": "1.1.5",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/space-separated-tokens/-/space-separated-tokens-1.1.5.tgz",
+      "integrity": "sha512-q/JSVd1Lptzhf5bkYm4ob4iWPjx0KiRe3sRFBNrVqbJkFaBm5vbbowy1mymoPNLRa52+oadOhJ+K49wsSeSjTA=="
     },
     "spdx-correct": {
       "version": "3.1.0",
@@ -3443,7 +3454,8 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "ssri": {
       "version": "4.1.6",
@@ -3453,10 +3465,15 @@
         "safe-buffer": "^5.1.0"
       }
     },
+    "stable": {
+      "version": "0.1.8",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/stable/-/stable-0.1.8.tgz",
+      "integrity": "sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w=="
+    },
     "store2": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/store2/-/store2-2.10.0.tgz",
-      "integrity": "sha512-tWEpK0snS2RPUq1i3R6OahfJNjWCQYNxq0+by1amCSuw0mXtymJpzmZIeYpA1UAa+7B0grCpNYIbDcd7AgTbFg=="
+      "version": "2.12.0",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/store2/-/store2-2.12.0.tgz",
+      "integrity": "sha512-7t+/wpKLanLzSnQPX8WAcuLCCeuSHoWdQuh9SB3xD0kNOM38DNf+0Oa+wmvxmYueRzkmh6IcdKFtvTa+ecgPDw=="
     },
     "stream-each": {
       "version": "1.2.3",
@@ -3489,6 +3506,24 @@
             "ansi-regex": "^3.0.0"
           }
         }
+      }
+    },
+    "string.prototype.trimend": {
+      "version": "1.0.1",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
+      }
+    },
+    "string.prototype.trimstart": {
+      "version": "1.0.1",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.5"
       }
     },
     "string_decoder": {
@@ -3558,19 +3593,27 @@
       }
     },
     "telejson": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/telejson/-/telejson-3.1.0.tgz",
-      "integrity": "sha512-mhiVy+xp2atri1bzSzdy/gVGXlOhibaoZ092AUq5xhnrZGdzhF0fLaOduHJQghkro+qmjYMwhsOL9CkD2zTicg==",
+      "version": "5.0.2",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/telejson/-/telejson-5.0.2.tgz",
+      "integrity": "sha512-XCrDHGbinczsscs8LXFr9jDhvy37yBk9piB7FJrCfxE8oP66WDkolNMpaBkWYgQqB9dQGBGtTDzGQPedc9KJmw==",
       "dev": true,
       "requires": {
         "@types/is-function": "^1.0.0",
         "global": "^4.4.0",
-        "is-function": "^1.0.1",
-        "is-regex": "^1.0.4",
-        "is-symbol": "^1.0.2",
+        "is-function": "^1.0.2",
+        "is-regex": "^1.1.1",
+        "is-symbol": "^1.0.3",
         "isobject": "^4.0.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.19",
         "memoizerific": "^1.11.3"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
+        }
       }
     },
     "term-size": {
@@ -3613,7 +3656,7 @@
     },
     "tinycolor2": {
       "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/tinycolor2/-/tinycolor2-1.4.1.tgz",
       "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g="
     },
     "tmp": {
@@ -3631,13 +3674,23 @@
     },
     "to-fast-properties": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
       "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
     },
     "toggle-selection": {
       "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/toggle-selection/-/toggle-selection-1.0.6.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/toggle-selection/-/toggle-selection-1.0.6.tgz",
       "integrity": "sha1-bkWxJj8gF/oKzH2J14sVuL932jI="
+    },
+    "ts-dedent": {
+      "version": "1.1.1",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/ts-dedent/-/ts-dedent-1.1.1.tgz",
+      "integrity": "sha512-UGTRZu1evMw4uTPyYF66/KFd22XiU+jMaIuHrkIHQ2GivAXVlLV0v/vHrpOuTRf9BmpNHi/SO7Vd0rLu0y57jg=="
+    },
+    "ts-essentials": {
+      "version": "2.0.12",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/ts-essentials/-/ts-essentials-2.0.12.tgz",
+      "integrity": "sha512-3IVX4nI6B5cc31/GFFE+i8ey/N2eA0CZDbo6n0yrz0zDX8ZJ8djmU1p+XRz7G3is0F3bB3pu2pAroFdAWQKU3w=="
     },
     "tslib": {
       "version": "1.10.0",
@@ -3684,7 +3737,7 @@
     },
     "typed-styles": {
       "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/typed-styles/-/typed-styles-0.0.7.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/typed-styles/-/typed-styles-0.0.7.tgz",
       "integrity": "sha512-pzP0PWoZUhsECYjABgCGQlRGL1n7tOHsgwYv3oIiEpJwGhFTuty/YNeduxQYzXXa3Ge5BdT6sHYIQYpl4uJ+5Q=="
     },
     "typedarray": {
@@ -3697,11 +3750,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
       "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
       "dev": true
-    },
-    "ua-parser-js": {
-      "version": "0.7.20",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.20.tgz",
-      "integrity": "sha512-8OaIKfzL5cpx8eCMAhhvTlft8GYF8b2eQr6JkCyVdrgjcytyOmPCXrqXFcUnhonRpLlh5yxEZVohm6mzaowUOw=="
     },
     "unique-filename": {
       "version": "1.1.1",
@@ -3734,7 +3782,7 @@
     },
     "unquote": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/unquote/-/unquote-1.1.1.tgz",
       "integrity": "sha1-j97XMk7G6IoP+LkF58CYzcCG1UQ="
     },
     "unzip-response": {
@@ -3767,6 +3815,27 @@
         "prepend-http": "^1.0.1"
       }
     },
+    "use-composed-ref": {
+      "version": "1.0.0",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/use-composed-ref/-/use-composed-ref-1.0.0.tgz",
+      "integrity": "sha512-RVqY3NFNjZa0xrmK3bIMWNmQ01QjKPDc7DeWR3xa/N8aliVppuutOE5bZzPkQfvL+5NRWMMp0DJ99Trd974FIw==",
+      "requires": {
+        "ts-essentials": "^2.0.3"
+      }
+    },
+    "use-isomorphic-layout-effect": {
+      "version": "1.0.0",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.0.0.tgz",
+      "integrity": "sha512-JMwJ7Vd86NwAt1jH7q+OIozZSIxA4ND0fx6AsOe2q1H8ooBUp5aN6DvVCqZiIaYU6JaMRJGyR0FO7EBCIsb/Rg=="
+    },
+    "use-latest": {
+      "version": "1.1.0",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/use-latest/-/use-latest-1.1.0.tgz",
+      "integrity": "sha512-gF04d0ZMV3AMB8Q7HtfkAWe+oq1tFXP6dZKwBHQF5nVXtGsh2oAYeeqma5ZzxtlpOcW8Ro/tLcfmEodjDeqtuw==",
+      "requires": {
+        "use-isomorphic-layout-effect": "^1.0.0"
+      }
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -3790,17 +3859,12 @@
       }
     },
     "warning": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
-      "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
+      "version": "4.0.3",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
       "requires": {
         "loose-envify": "^1.0.0"
       }
-    },
-    "whatwg-fetch": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-      "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
     },
     "which": {
       "version": "1.3.1",
@@ -3852,6 +3916,11 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+    },
+    "yaml": {
+      "version": "1.10.0",
+      "resolved": "http://nexus.dxtst.myriad.com/content/groups/npm-all/yaml/-/yaml-1.10.0.tgz",
+      "integrity": "sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     ],
     "homepage": "https://github.com/naver/storybook-addon-preview#readme",
     "dependencies": {
-        "@storybook/addon-knobs": "^5.2.0",
+        "@storybook/addon-knobs": "^6.0.21",
         "@types/prismjs": "^1.16.0",
         "@types/react-tabs": "^2.3.2",
         "codesandbox": "^2.1.10",
@@ -37,8 +37,8 @@
         "react-tabs": "^3.0.0"
     },
     "devDependencies": {
-        "@storybook/addons": "^5.2.6",
-        "@storybook/components": "^5.2.6",
+        "@storybook/addons": "^6.0.21",
+        "@storybook/components": "^6.0.21",
         "@types/node": "^12.12.7",
         "@types/react": "^16.9.11",
         "react": "^16.11.0",


### PR DESCRIPTION
addresses issue #12 

Adds support for [Storybook v6 Controls](https://storybook.js.org/docs/react/essentials/controls) which are a Storybook default add-on that will be completely replacing the knobs add-on in future versions of Storybook.

I was only able to test against my new v6 Storybook, as a result, I couldn't test whether the absence of any Controls would cause problems.  **_So, please test thoroughly for backwards compatibility!_**

Also, I saw a fair bit of `knob` related code in `index.tsx`, but everything _appears_ to be working okay for me without any modifications to that file. 🤷 